### PR TITLE
Update "journal" variable names missed in #48

### DIFF
--- a/newhelm/benchmark_runner.py
+++ b/newhelm/benchmark_runner.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import List
 from newhelm.benchmark import BaseBenchmark
-from newhelm.journal import BenchmarkRecord
+from newhelm.records import BenchmarkRecord
 from newhelm.sut import SUT
 
 

--- a/newhelm/demo_loading_benchmark.py
+++ b/newhelm/demo_loading_benchmark.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     runner = SimpleBenchmarkRunner("run_data")
     for benchmark in all_benchmarks:
         print("\n\nStarting:", benchmark.__class__.__name__)
-        benchmark_journals = runner.run(benchmark, all_suts)
-        for journal in benchmark_journals:
+        benchmark_records = runner.run(benchmark, all_suts)
+        for record in benchmark_records:
             # make it print pretty
-            print(to_json(journal, indent=4))
+            print(to_json(record, indent=4))

--- a/newhelm/plugins/runners/simple_benchmark_runner.py
+++ b/newhelm/plugins/runners/simple_benchmark_runner.py
@@ -5,7 +5,7 @@ from newhelm.base_test import BasePromptResponseTest
 from newhelm.benchmark import BaseBenchmark
 from newhelm.benchmark_runner import BaseBenchmarkRunner
 from newhelm.dependency_helper import FromSourceDependencyHelper
-from newhelm.journal import BenchmarkRecord, TestItemRecord, TestRecord
+from newhelm.records import BenchmarkRecord, TestItemRecord, TestRecord
 from newhelm.single_turn_prompt_response import (
     TestItemAnnotations,
     MeasuredTestItem,
@@ -36,28 +36,26 @@ class SimpleBenchmarkRunner(BaseBenchmarkRunner):
                 assert isinstance(sut, PromptResponseSUT)
 
         # Actually run the tests
-        benchmark_journals = []
+        benchmark_records = []
         for sut in suts:
-            test_journals = []
+            test_records = []
             for test in prompt_response_tests:
                 assert isinstance(
                     sut, PromptResponseSUT
                 )  # Redo the assert to make type checking happy.
-                test_journals.append(self._run_prompt_response_test(test, sut))
+                test_records.append(self._run_prompt_response_test(test, sut))
             # Run other kinds of tests on the SUT here
-            test_results = {
-                journal.test_name: journal.results for journal in test_journals
-            }
+            test_results = {record.test_name: record.results for record in test_records}
             score = benchmark.summarize(test_results)
-            benchmark_journals.append(
+            benchmark_records.append(
                 BenchmarkRecord(
                     benchmark.__class__.__name__,
                     sut.__class__.__name__,
-                    test_journals,
+                    test_records,
                     score,
                 )
             )
-        return benchmark_journals
+        return benchmark_records
 
     def _run_prompt_response_test(
         self, test: BasePromptResponseTest, sut: PromptResponseSUT
@@ -85,10 +83,10 @@ class SimpleBenchmarkRunner(BaseBenchmarkRunner):
             for item in item_interactions
         ]
         measured_test_items = []
-        test_item_journals = []
+        test_item_records = []
         for annotated in with_annotations:
             measurements = test.measure_quality(annotated)
-            test_item_journals.append(
+            test_item_records.append(
                 TestItemRecord(
                     annotated.test_item,
                     annotated.interactions,
@@ -104,6 +102,6 @@ class SimpleBenchmarkRunner(BaseBenchmarkRunner):
             test.__class__.__name__,
             dependency_helper.versions_used(),
             sut.__class__.__name__,
-            test_item_journals,
+            test_item_records,
             results,
         )

--- a/newhelm/records.py
+++ b/newhelm/records.py
@@ -31,7 +31,7 @@ class TestRecord:
     sut_name: str
     # TODO We should either reintroduce "Turns" here, or expect
     # there to b different schemas for different TestImplementationClasses.
-    test_item_journals: List[TestItemRecord]
+    test_item_records: List[TestItemRecord]
     results: List[Result]
 
 
@@ -41,5 +41,5 @@ class BenchmarkRecord:
 
     benchmark_name: str
     sut_name: str
-    test_journals: List[TestRecord]
+    test_records: List[TestRecord]
     score: Score


### PR DESCRIPTION
In PR #48 I renamed the classes, but I missed some of the variables. This should better align with [the naming doc](https://docs.google.com/document/d/1arvvv52_jrGyyZxAZPbYtDi2hCy1bC0iDrw6yByzSLg/edit).