### PR TITLE
Fix tmp directory issues

### DIFF
--- a/newhelm/dependency_helper.py
+++ b/newhelm/dependency_helper.py
@@ -145,7 +145,7 @@ class FromSourceDependencyHelper(DependencyHelper):
                 tmp_location = decompressed
             os.makedirs(os.path.join(self.data_dir, dependency_key), exist_ok=True)
             if not external_data.unpacker:
-                os.rename(tmp_location, final_path)
+                shutil.move(tmp_location, final_path)
             else:
                 self._unpack_dependency(
                     external_data.unpacker, tmp_location, final_path


### PR DESCRIPTION
Fixing so it works when the temporary directory and the cache are on different filesystems. (Note that this requires a cross-filesystem copy, so if we're expecting sufficiently large files, we may want to instead put the tmp_location closer to the final data resting point.)