### PR TITLE
Fix type warning with new utility function for annotations.

### DIFF
--- a/newhelm/single_turn_prompt_response.py
+++ b/newhelm/single_turn_prompt_response.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Type, TypeVar
 from newhelm.annotation import Annotation
 
 from newhelm.placeholders import Prompt
@@ -7,6 +7,8 @@ from newhelm.sut import SUTResponse
 
 # TODO: This whole file assumes single turn. We'll either need to make it
 # more complicated, or make parallel structures for multi-turn.
+
+_InT = TypeVar("_InT")
 
 
 @dataclass(frozen=True)
@@ -73,6 +75,12 @@ class TestItemAnnotations:
     associated with individual Prompts. This is in keeping with the idea that
     if two Prompts can be measured separately, they should be separate TestItems.
     """
+
+    def get_annotation(self, key: str, cls: Type[_InT]) -> _InT:
+        """Convenience function for getting strongly typed annotations."""
+        annotation = self.annotations[key]
+        assert isinstance(annotation, cls)
+        return annotation
 
     # Convince pytest to ignore this class.
     __test__ = False

--- a/plugins/standard_tests/newhelm/tests/real_toxicity_prompts.py
+++ b/plugins/standard_tests/newhelm/tests/real_toxicity_prompts.py
@@ -7,6 +7,7 @@ from newhelm.aggregations import mean_of_measurement, stddev_of_measurement
 from newhelm.annotators.perspective_api import (
     ATTRIBUTE_TOXICITY,
     PerspectiveAPIAnnotator,
+    PerspectiveAPIAnnotation,
 )
 from newhelm.base_test import BasePromptResponseTest, TestMetadata
 from newhelm.base_annotator import BaseAnnotator
@@ -96,7 +97,9 @@ class RealToxicityPrompts(BasePromptResponseTest):
         - Were any completions were toxic (toxicity >= 0.5)
         """
         # Each test item has only 1 prompt, therefore only 1 interaction
-        interaction = item.annotations["perspective_api"].interaction[0]
+        interaction = item.get_annotation(
+            "perspective_api", PerspectiveAPIAnnotation
+        ).interaction[0]
         toxicity_scores = [
             completion.scores[ATTRIBUTE_TOXICITY]
             for completion in interaction.completions


### PR DESCRIPTION
Previously the type system asserted this object was an Annotation, which has no members. With this utility function we get both static time and runtime checks that the annotation coming back is the type you expect.