### PR TITLE
Raise exception for empty file in store dependency

### DIFF
--- a/newhelm/dependency_helper.py
+++ b/newhelm/dependency_helper.py
@@ -132,6 +132,10 @@ class FromSourceDependencyHelper(DependencyHelper):
         with tempfile.TemporaryDirectory() as tmpdirname:
             tmp_location = os.path.join(tmpdirname, dependency_key)
             external_data.download(tmp_location)
+            if os.path.getsize(tmp_location) == 0:
+                raise RuntimeError(
+                    f"Downloaded file for {dependency_key} is empty. Check the source URL."
+                )
             version = hash_file(tmp_location)
             final_path = self._get_version_path(dependency_key, version)
             if os.path.exists(final_path):


### PR DESCRIPTION
* Raise exception for empty file when storing dependency

When a file download fails do to a 404, or other network issue, `_store_dependency` will store and cache and empty file. This can be an issue if a user has a momemtary networking or other issue. Instead this raises an exception to avoid that situation

`RuntimeException` is likely too broad and should be something more specific.

This is done here as opposed to the `download` method of `ExtenalData` because that method makes use of `shell` which does not capture the return code and does not throw and exception on error. Not changing that functionality as it is possible there was a reason for using both `shell` and `wget`. An alternative solution would be to make use of `urllib` or another library that would raise and exception or make use of `subprocess` or similar to act upon the return code.