### PR TITLE
Bump tqdm to >=4.66.1 to allow for global disable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 python = ">=3.10, <3.11"
 dacite = ">=1.6.0,<1.7.0"
 zstandard = ">=0.18.0,<0.19.0"
-tqdm = ">=4.64.1"
+tqdm = ">=4.66.1"
 types-tqdm = "^4.66.0.0"
 demo_plugin = {path = "demo_plugin", optional = true, develop = true}
 standard_tests = {path = "plugins/standard_tests", optional = true, develop = true}


### PR DESCRIPTION
* Bump tqdm to >=4.66.1 to allow for global disable for CI and other runner context `TQDM_DISABLE=1`

This is already what the poetry.lock file is at so we might as well make it official going forward
https://github.com/mlcommons/newhelm/blob/62386dc5f8451c824efef8c3c26e04cecaecabbd/poetry.lock#L2203

Release notes for change in tqdm
https://github.com/tqdm/tqdm/releases/tag/v4.66.0

Relates to #106 