### PR TITLE
Test demonstrating issue with pydantic serialization.

### DIFF
--- a/newhelm/records.py
+++ b/newhelm/records.py
@@ -21,6 +21,8 @@ class TestItemRecord(BaseModel):
     annotations: Dict[str, Annotation]
     measurements: Dict[str, float]
 
+    __test__ = False
+
 
 class TestRecord(BaseModel):
     """This is a rough sketch of the kind of data we'd want every Test to record."""
@@ -32,6 +34,8 @@ class TestRecord(BaseModel):
     # there to b different schemas for different TestImplementationClasses.
     test_item_records: List[TestItemRecord]
     results: List[Result]
+
+    __test__ = False
 
 
 class BenchmarkRecord(BaseModel):

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -145,4 +145,4 @@ def test_round_trip_prompt_with_context():
     returned = PromptWithContext.model_validate_json(as_json)
     # TODO Make this `assert prompt == returned`
     # This assertion is just demonstrating that we can't.
-    assert type(returned.context) == dict
+    assert type(returned.context) is dict

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -145,4 +145,4 @@ def test_round_trip_prompt_with_context():
     returned = PromptWithContext.model_validate_json(as_json)
     # TODO Make this `assert prompt == returned`
     # This assertion is just demonstrating that we can't.
-    assert returned.context.__class__.__name__ == "dict"
+    assert type(returned.context) == dict

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,0 +1,148 @@
+from pydantic import BaseModel
+from newhelm.annotation import Annotation
+from newhelm.placeholders import Prompt, Result, SUTOptions
+from newhelm.records import TestItemRecord, TestRecord
+from newhelm.single_turn_prompt_response import (
+    PromptInteraction,
+    PromptWithContext,
+    TestItem,
+)
+from newhelm.sut import SUTCompletion, SUTResponse
+
+
+class MockAnnotation(Annotation):
+    mock_field: str
+
+
+class MockContext(BaseModel):
+    context_field: str
+
+
+def test_serialize_test_record():
+    prompt = PromptWithContext(
+        prompt=Prompt(text="some-text", options=SUTOptions(max_tokens=17)),
+        context=MockContext(context_field="prompt-context"),
+    )
+
+    record = TestRecord(
+        test_name="some-test",
+        dependency_versions={"d1": "v1"},
+        sut_name="some-sut",
+        test_item_records=[
+            TestItemRecord(
+                test_item=TestItem(
+                    prompts=[prompt],
+                    context=MockContext(context_field="test-item-context"),
+                ),
+                interactions=[
+                    PromptInteraction(
+                        prompt=prompt,
+                        response=SUTResponse(
+                            completions=[SUTCompletion(text="sut-completion")]
+                        ),
+                    )
+                ],
+                annotations={"k1": MockAnnotation(mock_field="mock-value")},
+                measurements={"m1": 1.0},
+            )
+        ],
+        results=[Result(name="some-result", value=2.0)],
+    )
+    # TODO: This is dropping the Annotation's "mock_field" value.
+    assert (
+        record.model_dump_json(indent=2)
+        == """\
+{
+  "test_name": "some-test",
+  "dependency_versions": {
+    "d1": "v1"
+  },
+  "sut_name": "some-sut",
+  "test_item_records": [
+    {
+      "test_item": {
+        "prompts": [
+          {
+            "prompt": {
+              "text": "some-text",
+              "options": {
+                "num_completions": 1,
+                "max_tokens": 17,
+                "temperature": null,
+                "top_k_per_token": null,
+                "stop_sequences": null,
+                "echo_prompt": null,
+                "top_p": null,
+                "presence_penalty": null,
+                "frequency_penalty": null,
+                "random": null
+              }
+            },
+            "context": {
+              "context_field": "prompt-context"
+            }
+          }
+        ],
+        "context": {
+          "context_field": "test-item-context"
+        }
+      },
+      "interactions": [
+        {
+          "prompt": {
+            "prompt": {
+              "text": "some-text",
+              "options": {
+                "num_completions": 1,
+                "max_tokens": 17,
+                "temperature": null,
+                "top_k_per_token": null,
+                "stop_sequences": null,
+                "echo_prompt": null,
+                "top_p": null,
+                "presence_penalty": null,
+                "frequency_penalty": null,
+                "random": null
+              }
+            },
+            "context": {
+              "context_field": "prompt-context"
+            }
+          },
+          "response": {
+            "completions": [
+              {
+                "text": "sut-completion"
+              }
+            ]
+          }
+        }
+      ],
+      "annotations": {
+        "k1": {}
+      },
+      "measurements": {
+        "m1": 1.0
+      }
+    }
+  ],
+  "results": [
+    {
+      "name": "some-result",
+      "value": 2.0
+    }
+  ]
+}"""
+    )
+
+
+def test_round_trip_prompt_with_context():
+    prompt = PromptWithContext(
+        prompt=Prompt(text="some-text", options=SUTOptions(max_tokens=17)),
+        context=MockContext(context_field="prompt-context"),
+    )
+    as_json = prompt.model_dump_json()
+    returned = PromptWithContext.model_validate_json(as_json)
+    # TODO Make this `assert prompt == returned`
+    # This assertion is just demonstrating that we can't.
+    assert returned.context.__class__.__name__ == "dict"

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,43 @@
+from abc import ABC
+from typing import List
+from pydantic import BaseModel
+
+
+class SomeBase(BaseModel, ABC):
+    all_have: int
+
+
+class Derived1(SomeBase):
+    field_1: int
+
+
+class Derived2(SomeBase):
+    field_2: int
+
+
+class Wrapper(BaseModel):
+    elements: List[SomeBase]
+    bar: str
+
+def test_pydantic_lack_of_polymorphism_serialize():
+    """This test is showing that Pydantic doesn't serialize like we want."""
+    wrapper = Wrapper(
+        elements=[Derived1(all_have=20, field_1=1), Derived2(all_have=20, field_2=2)],
+        bar="foo"
+    )
+    # This is missing field_1 and field_2
+    assert wrapper.model_dump_json() == (
+        """{"elements":[{"all_have":20},{"all_have":20}]}"""
+    )
+
+
+def test_pydantic_lack_of_polymorphism_deserialize():
+    """This test is showing that Pydantic doesn't deserialize like we want."""
+
+    from_json = Wrapper.model_validate_json(
+        """{"elements":[{"all_have":20, "field_1": 1},{"all_have":20, "field_2": 2}]}""",
+        strict=True,
+    )
+    # These should be Derived1 and Derived2
+    assert from_json.elements[0].__class__.__name__ == "SomeBase"
+    assert from_json.elements[1].__class__.__name__ == "SomeBase"

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -40,7 +40,7 @@ def test_pydantic_lack_of_polymorphism_deserialize():
         strict=True,
     )
     # These should be Derived1 and Derived2
-    assert from_json.elements[0].__class__.__name__ == "SomeBase"
-    assert from_json.elements[1].__class__.__name__ == "SomeBase"
+    assert type(from_json.elements[0]) == SomeBase
+    assert type(from_json.elements[1]) == SomeBase
     # This should be Derived1
-    assert from_json.any_union.__class__.__name__ == "dict"
+    assert type(from_json.any_union) == dict

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -40,7 +40,7 @@ def test_pydantic_lack_of_polymorphism_deserialize():
         strict=True,
     )
     # These should be Derived1 and Derived2
-    assert type(from_json.elements[0]) == SomeBase
-    assert type(from_json.elements[1]) == SomeBase
+    assert type(from_json.elements[0]) is SomeBase
+    assert type(from_json.elements[1]) is SomeBase
     # This should be Derived1
-    assert type(from_json.any_union) == dict
+    assert type(from_json.any_union) is dict

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import List
+from typing import Any, List
 from pydantic import BaseModel
 
 
@@ -17,17 +17,18 @@ class Derived2(SomeBase):
 
 class Wrapper(BaseModel):
     elements: List[SomeBase]
-    bar: str
+    any_union: Any
+
 
 def test_pydantic_lack_of_polymorphism_serialize():
     """This test is showing that Pydantic doesn't serialize like we want."""
     wrapper = Wrapper(
         elements=[Derived1(all_have=20, field_1=1), Derived2(all_have=20, field_2=2)],
-        bar="foo"
+        any_union=Derived1(all_have=30, field_1=3),
     )
-    # This is missing field_1 and field_2
+    # This is missing field_1 and field_2 in elements
     assert wrapper.model_dump_json() == (
-        """{"elements":[{"all_have":20},{"all_have":20}]}"""
+        """{"elements":[{"all_have":20},{"all_have":20}],"any_union":{"all_have":30,"field_1":3}}"""
     )
 
 
@@ -35,9 +36,11 @@ def test_pydantic_lack_of_polymorphism_deserialize():
     """This test is showing that Pydantic doesn't deserialize like we want."""
 
     from_json = Wrapper.model_validate_json(
-        """{"elements":[{"all_have":20, "field_1": 1},{"all_have":20, "field_2": 2}]}""",
+        """{"elements":[{"all_have":20, "field_1": 1},{"all_have":20, "field_2": 2}],"any_union":{"all_have":30,"field_1":3}}""",
         strict=True,
     )
     # These should be Derived1 and Derived2
     assert from_json.elements[0].__class__.__name__ == "SomeBase"
     assert from_json.elements[1].__class__.__name__ == "SomeBase"
+    # This should be Derived1
+    assert from_json.any_union.__class__.__name__ == "dict"


### PR DESCRIPTION
Where this shows up for real is allowing anyone to extend a datatype we serialize, and still have it be serialized correctly. For example, the "context" on PromptWithContext and the child classes of `Annotation`.