### PR TITLE
Stop assuming that the Test and SUT class uniquely identify the instance.

### DIFF
--- a/demo_plugin/newhelm/benchmarks/demo_benchmark.py
+++ b/demo_plugin/newhelm/benchmarks/demo_benchmark.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Mapping
 from newhelm.benchmark_registry import BENCHMARKS
 from newhelm.tests.demo_02_unpacking_dependency_test import (
     DemoUnpackingDependencyTest,
@@ -17,13 +17,13 @@ from newhelm.placeholders import Result
 class DemoBenchmark(BaseBenchmark):
     """A benchmark that runs all of the Demo Tests."""
 
-    def get_tests(self) -> List[BaseTest]:
-        """Returns the list of all Test objects this benchmark wants to run."""
-        return [
-            DemoSimpleQATest(),
-            DemoUnpackingDependencyTest(),
-            DemoPairedPromptsTest(),
-        ]
+    def get_tests(self) -> Mapping[str, BaseTest]:
+        """All of the demo Tests."""
+        return {
+            "demo_01": DemoSimpleQATest(),
+            "demo_02": DemoUnpackingDependencyTest(),
+            "demo_03": DemoPairedPromptsTest(),
+        }
 
     def summarize(self, results: Dict[str, List[Result]]) -> Score:
         """This demo reports the mean over all test Results."""

--- a/newhelm/benchmark.py
+++ b/newhelm/benchmark.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, List
+from typing import Dict, List, Mapping
 
 from pydantic import BaseModel
 
@@ -16,8 +16,11 @@ class BaseBenchmark(ABC):
     """The base for all benchmarks."""
 
     @abstractmethod
-    def get_tests(self) -> List[BaseTest]:
-        """Return a list of tests that compose this Benchmark."""
+    def get_tests(self) -> Mapping[str, BaseTest]:
+        """Return a mapping of tests that compose this Benchmark.
+
+        The keys can be arbitrary strings, and are forwarded to `summarize`.
+        """
         pass
 
     @abstractmethod

--- a/newhelm/benchmark_runner.py
+++ b/newhelm/benchmark_runner.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Mapping
 from newhelm.benchmark import BaseBenchmark
 from newhelm.records import BenchmarkRecord
 from newhelm.sut import SUT
@@ -12,5 +12,7 @@ class BaseBenchmarkRunner(ABC):
     """
 
     @abstractmethod
-    def run(self, benchmark: BaseBenchmark, suts: List[SUT]) -> List[BenchmarkRecord]:
+    def run(
+        self, benchmark: BaseBenchmark, suts: Mapping[str, SUT]
+    ) -> List[BenchmarkRecord]:
         pass

--- a/newhelm/runners/simple_benchmark_runner.py
+++ b/newhelm/runners/simple_benchmark_runner.py
@@ -1,6 +1,6 @@
 import os
 import random
-from typing import Dict, List, Optional
+from typing import Dict, List, Mapping, Optional
 from tqdm import tqdm
 from newhelm.annotation import Annotation
 from newhelm.base_test import BasePromptResponseTest
@@ -24,31 +24,38 @@ class SimpleBenchmarkRunner(BaseBenchmarkRunner):
         self.data_dir = data_dir
         self.max_test_items = max_test_items
 
-    def run(self, benchmark: BaseBenchmark, suts: List[SUT]) -> List[BenchmarkRecord]:
+    def run(
+        self, benchmark: BaseBenchmark, suts: Mapping[str, SUT]
+    ) -> List[BenchmarkRecord]:
         # Not all runners can run all Test types, so validate up front
-        prompt_response_tests: List[BasePromptResponseTest] = []
-        for test in benchmark.get_tests():
+        prompt_response_tests: Dict[str, BasePromptResponseTest] = {}
+        for test_name, test in benchmark.get_tests().items():
             if isinstance(test, BasePromptResponseTest):
-                prompt_response_tests.append(test)
+                prompt_response_tests[test_name] = test
             else:
-                raise Exception("Runner can't handle test:", test.__class__.__name__)
+                raise Exception("Runner can't handle test:", test_name)
 
         # Validate all SUTs can do the requested test types
         if prompt_response_tests:
-            for sut in suts:
+            for sut in suts.values():
                 assert isinstance(sut, PromptResponseSUT)
 
         # Actually run the tests
         benchmark_records = []
-        for sut in suts:
+        for sut_name, sut in suts.items():
             test_records = []
-            for test in prompt_response_tests:
+            for test_name, test in prompt_response_tests.items():
                 assert isinstance(
                     sut, PromptResponseSUT
                 )  # Redo the assert to make type checking happy.
                 test_records.append(
                     run_prompt_response_test(
-                        test, sut, self.data_dir, self.max_test_items
+                        test_name,
+                        test,
+                        sut_name,
+                        sut,
+                        self.data_dir,
+                        self.max_test_items,
                     )
                 )
             # Run other kinds of tests on the SUT here
@@ -57,7 +64,7 @@ class SimpleBenchmarkRunner(BaseBenchmarkRunner):
             benchmark_records.append(
                 BenchmarkRecord(
                     benchmark_name=benchmark.__class__.__name__,
-                    sut_name=sut.__class__.__name__,
+                    sut_name=sut_name,
                     test_records=test_records,
                     score=score,
                 )
@@ -66,7 +73,9 @@ class SimpleBenchmarkRunner(BaseBenchmarkRunner):
 
 
 def run_prompt_response_test(
+    test_name: str,
     test: BasePromptResponseTest,
+    sut_name: str,
     sut: PromptResponseSUT,
     data_dir: str,
     max_test_items: Optional[int] = None,
@@ -84,7 +93,7 @@ def run_prompt_response_test(
         random.seed(0)
         test_items = random.sample(test_items, max_test_items)
     item_interactions: List[TestItemInteractions] = []
-    desc = f"Collecting responses to {test.__class__.__name__} from {sut.__class__.__name__}"
+    desc = f"Collecting responses to {test_name} from {sut_name}"
     for item in tqdm(test_items, desc=desc):
         interactions = []
         for prompt in item.prompts:
@@ -135,9 +144,9 @@ def run_prompt_response_test(
         )
     results = test.aggregate_measurements(measured_test_items)
     return TestRecord(
-        test_name=test.__class__.__name__,
+        test_name=test_name,
         dependency_versions=dependency_helper.versions_used(),
-        sut_name=sut.__class__.__name__,
+        sut_name=sut_name,
         test_item_records=test_item_records,
         results=results,
     )

--- a/newhelm/runners/simple_benchmark_runner_cli.py
+++ b/newhelm/runners/simple_benchmark_runner_cli.py
@@ -33,7 +33,9 @@ def run_test(test: str, sut: str, data_dir: str, secrets: str, max_test_items: i
     assert isinstance(sut_obj, PromptResponseSUT)
     assert isinstance(test_obj, BasePromptResponseTest)
 
-    test_journal = run_prompt_response_test(test_obj, sut_obj, data_dir, max_test_items)
+    test_journal = run_prompt_response_test(
+        test, test_obj, sut, sut_obj, data_dir, max_test_items
+    )
     print(test_journal.model_dump_json(indent=4))
 
 
@@ -48,7 +50,7 @@ def run_benchmark(benchmark, sut, data_dir, secrets, max_test_items):
     sut_obj = SUTS.make_instance(sut)
     SECRETS.set_values(get_or_create_json_file(secrets))
     runner = SimpleBenchmarkRunner(data_dir, max_test_items)
-    benchmark_records = runner.run(benchmark_obj, [sut_obj])
+    benchmark_records = runner.run(benchmark_obj, {sut: sut_obj})
     for record in benchmark_records:
         # make it print pretty
         print(record.model_dump_json(indent=4))


### PR DESCRIPTION
Previously the `TestRecord` and `BenchmarkRecord` would say the sut_name was `TogetherCompletionsSUT` for both `llama-2-7b` and `llama-2-70b`. Similarly if you initialized BBQ with 5 different subjects, they would all be BBQ.

Now the user can specify an arbitrary name for Tests and SUTs.