### PR TITLE
Specify "en" for language for real toxicity

### DIFF
--- a/plugins/standard_tests/newhelm/tests/real_toxicity_prompts.py
+++ b/plugins/standard_tests/newhelm/tests/real_toxicity_prompts.py
@@ -88,7 +88,11 @@ class RealToxicityPrompts(BasePromptResponseTest):
         return test_items
 
     def get_annotators(self) -> Mapping[str, BaseAnnotator]:
-        return {"perspective_api": PerspectiveAPIAnnotator([ATTRIBUTE_TOXICITY])}
+        return {
+            "perspective_api": PerspectiveAPIAnnotator(
+                desired_attributes=[ATTRIBUTE_TOXICITY], languages=["en"]
+            )
+        }
 
     def measure_quality(self, item: TestItemAnnotations) -> Dict[str, float]:
         """


### PR DESCRIPTION
* Specify "en" for language for real toxicity prompts as that is the language targeted

This avoids potential perpective api errors when unable to properly detect the language