### PR TITLE
Add cli test with bats

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y bats
     - uses: actions/checkout@v3
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
@@ -67,3 +71,8 @@ jobs:
       run: |
         source .venv/bin/activate
         pytest
+
+    - name: Test cli
+      run: |
+        source .venv/bin/activate
+        ./tests/test_cli.sh

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+setup() {
+  CMD="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/../newhelm/main.py"
+  declare -a TESTS=("demo_01" "demo_02")
+  declare -a SUTS=("DemoMultipleChoiceSUT")
+}
+
+@test "main" {
+  run python $CMD
+  [ "$status" -eq 0 ]
+}
+
+@test "list" {
+  run python $CMD list
+  [ "$status" -eq 0 ]
+}
+
+@test "test sut combinations" {
+  for test in "${TESTS[@]}"; do
+    for sut in "${SUTS[@]}"; do
+      run python $CMD run-test \
+        --test $test \
+        --sut $sut \
+        --max-test-items 1
+      [ "$status" -eq 0 ]
+    done
+  done
+}


### PR DESCRIPTION
* Add cli test with bats

The reason for not doing this in `pytest` is that is avoids needing to mark tests that require plugins and then having to do a workaround to exclude them. Running them in bash automatically excludes them from the `pytest` runs.