### PR TITLE
Add simple bash cli test

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -67,3 +67,8 @@ jobs:
       run: |
         source .venv/bin/activate
         pytest
+
+    - name: Test cli
+      run: |
+        source .venv/bin/activate
+        ./tests/test_cli.sh

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+export TQDM_DISABLE=1
+
+CMD="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )/../newhelm/main.py"
+
+declare -a TESTS=("demo_01" "demo_02")
+declare -a SUTS=("DemoMultipleChoiceSUT")
+
+echo "Test main"
+python $CMD > /dev/null
+
+echo "Test list"
+python $CMD list > /dev/null
+
+echo "Test run-test test sut combinations"
+for test in "${TESTS[@]}"; do
+  for sut in "${SUTS[@]}"; do
+    echo "Test $test with $sut"
+    python $CMD run-test \
+      --test $test \
+      --sut $sut \
+      --max-test-items 1 > /dev/null
+  done
+done


### PR DESCRIPTION
* Add simple bash cli test

This leverages the fact that any failures on these commands will have a non-zero exit code and fail the CI run. This option avoids needing to install an additional tool which would require add `apt-get update`.

See #124
See #125

Closes #124
Closes #125