### PR TITLE
Fix openai sut for change to pydantic

### DIFF
--- a/plugins/openai/newhelm/suts/openai_client.py
+++ b/plugins/openai/newhelm/suts/openai_client.py
@@ -87,7 +87,7 @@ class OpenAIChat(PromptResponseSUT[OpenAIChatRequest, ChatCompletion]):
         if self.client is None:
             # Handle lazy init.
             self.client = self._load_client()
-        request_dict = asdict_without_nones(request)
+        request_dict = request.model_dump(exclude_none=True)
         return self.client.chat.completions.create(**request_dict)
 
     def translate_response(


### PR DESCRIPTION
* Fix openai sut for change to pydantic

Change to `model_dump` and use `exclude_none` to prevent 400 errors with openai api type checking

```
File "newhelm/plugins/openai/newhelm/suts/openai_client.py", line 90, in evaluate
    request_dict = asdict_without_nones(request)
File "newhelm/newhelm/general.py", line 29, in asdict_without_nones
    raise ValueError(f"Expected dataclass, got '{obj}'")
```