### PR TITLE
Stop having pytest look in source directories for tests.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ mypy = "^1.7.1"
 black = "^23.11.0"
 pytest-mock = "^3.12.0"
 
+[tool.pytest.ini_options]
+# Ignore the main source that might have things named "test"
+addopts="--ignore=newhelm/ --ignore=demo_plugin/newhelm/ --ignore=plugins/*/newhelm/"
+
 [tool.mypy]
 # Using namespace packages to do plugins requires us not to have __init__.py files.
 # However, by default mypy uses those to map file paths to modules. This override fixes that.


### PR DESCRIPTION
Structured as a negative instead of a positive as we can be sure there won't be tests here, but we may want to make new directories in the future that do have tests.