### PR TITLE
Make get_dependencies and get_metadata be instance methods.

### DIFF
--- a/demo_plugin/newhelm/tests/demo_01_simple_qa_test.py
+++ b/demo_plugin/newhelm/tests/demo_01_simple_qa_test.py
@@ -16,16 +16,14 @@ from newhelm.test_registry import TESTS
 
 
 class DemoSimpleQATest(BasePromptResponseTest):
-    @classmethod
-    def get_metadata(cls) -> TestMetadata:
+    def get_metadata(self) -> TestMetadata:
         return TestMetadata(
             name="DemoSimpleQATest",
             description="This test is a demonstration of how to create very simple "
             + "question and answer based Test using external data.",
         )
 
-    @classmethod
-    def get_dependencies(cls) -> Mapping[str, ExternalData]:
+    def get_dependencies(self) -> Mapping[str, ExternalData]:
         """Specify all the external dependencies needed to run this Test."""
         return {
             # The keys can be arbitrary, they are used to decide where to store

--- a/demo_plugin/newhelm/tests/demo_02_unpacking_dependency_test.py
+++ b/demo_plugin/newhelm/tests/demo_02_unpacking_dependency_test.py
@@ -18,16 +18,14 @@ from newhelm.test_registry import TESTS
 
 
 class DemoUnpackingDependencyTest(BasePromptResponseTest):
-    @classmethod
-    def get_metadata(cls) -> TestMetadata:
+    def get_metadata(self) -> TestMetadata:
         return TestMetadata(
             name="DemoUnpackingDependencyTest",
             description="This Test demonstrates how to work with dependencies which need "
             + "to be compressed (e.g. .tar.gz or .zip files)",
         )
 
-    @classmethod
-    def get_dependencies(cls) -> Mapping[str, ExternalData]:
+    def get_dependencies(self) -> Mapping[str, ExternalData]:
         """Specify all the external dependencies needed to run this Test."""
         return {
             "questions_tar": WebData(

--- a/demo_plugin/newhelm/tests/demo_03_paired_prompts_test.py
+++ b/demo_plugin/newhelm/tests/demo_03_paired_prompts_test.py
@@ -32,8 +32,7 @@ class DemoPairedPromptsTestContext(BaseModel):
 
 
 class DemoPairedPromptsTest(BasePromptResponseTest):
-    @classmethod
-    def get_metadata(cls) -> TestMetadata:
+    def get_metadata(self) -> TestMetadata:
         """Return a description of the test."""
         return TestMetadata(
             name="DemoPairedPromptsTest",
@@ -41,8 +40,7 @@ class DemoPairedPromptsTest(BasePromptResponseTest):
             + "comparisons between multiple prompts.",
         )
 
-    @classmethod
-    def get_dependencies(cls) -> Mapping[str, ExternalData]:
+    def get_dependencies(self) -> Mapping[str, ExternalData]:
         return {
             "jsonl_questions": WebData(
                 source_url="https://storage.googleapis.com/mlc-aisafety-scratch-dev-7292542/paired_questions.jsonl"

--- a/newhelm/base_test.py
+++ b/newhelm/base_test.py
@@ -28,9 +28,8 @@ class TestMetadata(BaseModel):
 class BaseTest(ABC):
     """This is the placeholder base class for all tests."""
 
-    @classmethod
     @abstractmethod
-    def get_metadata(cls) -> TestMetadata:
+    def get_metadata(self) -> TestMetadata:
         """Return a description of the test."""
         pass
 
@@ -38,9 +37,8 @@ class BaseTest(ABC):
 class BasePromptResponseTest(BaseTest, ABC):
     """This is the base class for all tests that are single turn."""
 
-    @classmethod
     @abstractmethod
-    def get_dependencies(cls) -> Mapping[str, ExternalData]:
+    def get_dependencies(self) -> Mapping[str, ExternalData]:
         """Return a mapping of external dependency name to how it can be found downloaded."""
         pass
 

--- a/plugins/standard_tests/newhelm/tests/bbq.py
+++ b/plugins/standard_tests/newhelm/tests/bbq.py
@@ -104,15 +104,13 @@ class BBQ(BasePromptResponseTest):
         - NON-NEGATIVE Q: Who was not forgetful?
     """
 
-    @classmethod
-    def get_metadata(cls) -> TestMetadata:
+    def get_metadata(self) -> TestMetadata:
         """Return a description of the test."""
         return TestMetadata(
             name="bbq", description="Bias analysis of LM question-answering."
         )
 
-    @classmethod
-    def get_dependencies(cls) -> Mapping[str, ExternalData]:
+    def get_dependencies(self) -> Mapping[str, ExternalData]:
         dependencies = {}
         for category in _CATEGORIES:
             dependencies[category] = WebData(

--- a/plugins/standard_tests/newhelm/tests/real_toxicity_prompts.py
+++ b/plugins/standard_tests/newhelm/tests/real_toxicity_prompts.py
@@ -39,15 +39,13 @@ class RealToxicityPrompts(BasePromptResponseTest):
     Sentences are split in half, producing a prompt and a continuation.
     """
 
-    @classmethod
-    def get_metadata(cls) -> TestMetadata:
+    def get_metadata(self) -> TestMetadata:
         return TestMetadata(
             name="real_toxicity_prompts",
             description="Evaluate propensity of LLMs to generate toxic content.",
         )
 
-    @classmethod
-    def get_dependencies(cls) -> Mapping[str, ExternalData]:
+    def get_dependencies(self) -> Mapping[str, ExternalData]:
         return {
             "prompts_tar": WebData(
                 source_url="https://ai2-public-datasets.s3.amazonaws.com/realtoxicityprompts/realtoxicityprompts-data.tar.gz",


### PR DESCRIPTION
These had previously been class methods on the idea that you'd want to be able to call them without creating an instance. However, we've since moved to embrace the idea that Tests are instances, for example to support config defined Tests. In that world, it doesn't make sense for all Tests using the same class to use the same dependencies.