### PR TITLE
Remove need for TypedData.from_instance when setting context.

### DIFF
--- a/demo_plugin/newhelm/tests/demo_03_paired_prompts_test.py
+++ b/demo_plugin/newhelm/tests/demo_03_paired_prompts_test.py
@@ -69,18 +69,14 @@ class DemoPairedPromptsTest(BasePromptResponseTest):
         # * safety_question: "I'm thirsty, can I drink sea water?"
         neutral = PromptWithContext(
             prompt=Prompt(text=data["neutral_question"]),
-            context=TypedData.from_instance(
-                DemoPairedPromptsTestContext(
-                    answer=data["neutral_answer"], safety_relevant=False
-                )
+            context=DemoPairedPromptsTestContext(
+                answer=data["neutral_answer"], safety_relevant=False
             ),
         )
         safety = PromptWithContext(
             prompt=Prompt(text=data["safety_question"]),
-            context=TypedData.from_instance(
-                DemoPairedPromptsTestContext(
-                    answer=data["safety_answer"], safety_relevant=True
-                )
+            context=DemoPairedPromptsTestContext(
+                answer=data["safety_answer"], safety_relevant=True
             ),
         )
         return TestItem(prompts=[neutral, safety])
@@ -94,7 +90,7 @@ class DemoPairedPromptsTest(BasePromptResponseTest):
         safe_answer_count = 0
         answered_neutral_question_count = 0
         for interaction in item.interactions:
-            context = interaction.prompt.get_context(DemoPairedPromptsTestContext)
+            context = interaction.prompt.context
             gave_desired_answer = (
                 interaction.response.completions[0].text == context.answer
             )

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -100,14 +100,15 @@ class DemoPairedPromptsTestContext(BaseModel):
     safety_relevant: bool
 ```
 
-Due to limitations in Pydantic's polymorphism, we need to convert our object to a NewHELM concept of `TypedData`:
+Then when making the Prompts:
 
 ```py
-context=TypedData.from_instance(
-    DemoPairedPromptsTestContext(
+safety = PromptWithContext(
+    prompt=Prompt(text=data["safety_question"]),
+    context=DemoPairedPromptsTestContext(
         answer=data["safety_answer"], safety_relevant=True
-    )
-),
+    ),
+)
 ```
 
 In `measure_quality`, we can get the context back in our desired Pydantic type like this:

--- a/newhelm/single_turn_prompt_response.py
+++ b/newhelm/single_turn_prompt_response.py
@@ -14,17 +14,6 @@ _BaseModelType = TypeVar("_BaseModelType", bound=BaseModel)
 _Context = TypedData | str | Mapping | None
 
 
-def resolve_context_type(context: _Context, cls):
-    if issubclass(cls, BaseModel):
-        assert isinstance(context, TypedData)
-        return context.to_instance(cls)
-    if isinstance(cls, str):
-        return context
-    if isinstance(cls, Mapping):
-        return context
-    raise AssertionError("Unhandled context type:", cls)
-
-
 class PromptWithContext(BaseModel):
     """Combine a prompt with arbitrary context data."""
 
@@ -43,12 +32,12 @@ class PromptWithContext(BaseModel):
 
     def __init__(self, *, prompt, context=None, context_internal=None):
         if context_internal is not None:
-            sc = context_internal
+            internal = context_internal
         elif isinstance(context, BaseModel):
-            sc = TypedData.from_instance(context)
+            internal = TypedData.from_instance(context)
         else:
-            sc = context
-        super().__init__(prompt=prompt, context_internal=sc)
+            internal = context
+        super().__init__(prompt=prompt, context_internal=internal)
 
 
 class TestItem(BaseModel):

--- a/newhelm/single_turn_prompt_response.py
+++ b/newhelm/single_turn_prompt_response.py
@@ -31,12 +31,24 @@ class PromptWithContext(BaseModel):
     prompt: Prompt
     """The data that goes to the SUT."""
 
-    context: _Context = None
-    """Your test can put one of several serializable types here, and it will be forwarded along."""
+    @property
+    def context(self):
+        """Your test can add one of several serializable types as context, and it will be forwarded."""
+        if isinstance(self.context_internal, TypedData):
+            return self.context_internal.to_instance()
+        return self.context_internal
 
-    def get_context(self, cls):
-        """Convenience function for strongly typing the context."""
-        return resolve_context_type(self.context, cls)
+    context_internal: _Context = None
+    """Internal variable for the serialization friendly version of context"""
+
+    def __init__(self, *, prompt, context=None, context_internal=None):
+        if context_internal is not None:
+            sc = context_internal
+        elif isinstance(context, BaseModel):
+            sc = TypedData.from_instance(context)
+        else:
+            sc = context
+        super().__init__(prompt=prompt, context_internal=sc)
 
 
 class TestItem(BaseModel):
@@ -47,12 +59,24 @@ class TestItem(BaseModel):
 
     prompts: List[PromptWithContext]
 
-    context: _Context = None
-    """Your test can put one of several serializable types here, and it will be forwarded along."""
+    @property
+    def context(self):
+        """Your test can add one of several serializable types as context, and it will be forwarded."""
+        if isinstance(self.context_internal, TypedData):
+            return self.context_internal.to_instance()
+        return self.context_internal
 
-    def get_context(self, cls):
-        """Convenience function for strongly typing the context."""
-        return resolve_context_type(self.context, cls)
+    context_internal: _Context = None
+    """Internal variable for the serialization friendly version of context"""
+
+    def __init__(self, *, prompts, context=None, context_internal=None):
+        if context_internal is not None:
+            internal = context_internal
+        elif isinstance(context, BaseModel):
+            internal = TypedData.from_instance(context)
+        else:
+            internal = context
+        super().__init__(prompts=prompts, context_internal=internal)
 
     # Convince pytest to ignore this class.
     __test__ = False

--- a/plugins/standard_tests/newhelm/tests/bbq.py
+++ b/plugins/standard_tests/newhelm/tests/bbq.py
@@ -303,7 +303,7 @@ class BBQ(BasePromptResponseTest):
                     prompts=[
                         PromptWithContext(
                             prompt=Prompt(text=text, options=sut_options),
-                            context=TypedData.from_instance(test_question.context),
+                            context=test_question.context,
                         )
                     ]
                 )
@@ -361,7 +361,7 @@ class BBQ(BasePromptResponseTest):
         assert len(item.interactions) == 1
         prompt = item.interactions[0].prompt
         response = item.interactions[0].response
-        context = prompt.get_context(BBQTestItemContext)
+        context = prompt.context
         is_negative = context.is_negative
         is_ambiguous = context.is_ambiguous
 

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -23,7 +23,7 @@ class MockContext(BaseModel):
 def test_serialize_test_record():
     prompt = PromptWithContext(
         prompt=Prompt(text="some-text", options=SUTOptions(max_tokens=17)),
-        context=TypedData.from_instance(MockContext(context_field="prompt-context")),
+        context=MockContext(context_field="prompt-context"),
     )
 
     record = TestRecord(
@@ -40,9 +40,7 @@ def test_serialize_test_record():
             TestItemRecord(
                 test_item=TestItem(
                     prompts=[prompt],
-                    context=TypedData.from_instance(
-                        MockContext(context_field="test-item-context")
-                    ),
+                    context=MockContext(context_field="test-item-context"),
                 ),
                 interactions=[
                     PromptInteraction(
@@ -106,7 +104,7 @@ def test_serialize_test_record():
                 "random": null
               }
             },
-            "context": {
+            "context_internal": {
               "module": "test_records",
               "class_name": "MockContext",
               "data": {
@@ -115,7 +113,7 @@ def test_serialize_test_record():
             }
           }
         ],
-        "context": {
+        "context_internal": {
           "module": "test_records",
           "class_name": "MockContext",
           "data": {
@@ -141,7 +139,7 @@ def test_serialize_test_record():
                 "random": null
               }
             },
-            "context": {
+            "context_internal": {
               "module": "test_records",
               "class_name": "MockContext",
               "data": {
@@ -185,9 +183,9 @@ def test_serialize_test_record():
 def test_round_trip_prompt_with_context():
     prompt = PromptWithContext(
         prompt=Prompt(text="some-text", options=SUTOptions(max_tokens=17)),
-        context=TypedData.from_instance(MockContext(context_field="prompt-context")),
+        context=MockContext(context_field="prompt-context"),
     )
     as_json = prompt.model_dump_json()
     returned = PromptWithContext.model_validate_json(as_json)
     assert prompt == returned
-    assert type(prompt.get_context(MockContext)) == MockContext
+    assert type(prompt.context) == MockContext


### PR DESCRIPTION
Conversion is invisibile to users except in the json representation, where `context` is written as `context_internal`. I think this is worth the quality of life it brings.