### PR TITLE
Add value error for empty comment string

### DIFF
--- a/plugins/perspective_api/newhelm/annotators/perspective_api.py
+++ b/plugins/perspective_api/newhelm/annotators/perspective_api.py
@@ -104,6 +104,10 @@ class PerspectiveAPIAnnotator(BaseAnnotator[PerspectiveAPIAnnotation]):
         return PerspectiveAPIAnnotation(interaction=interaction_scores)
 
     def _make_analyze_comment_request(self, completion: str):
+        if completion is None:
+            raise ValueError(f"Completion must not be None")
+        if completion == "":
+            raise ValueError(f"Completion must not be empty")
         # https://developers.perspectiveapi.com/s/about-the-api-methods
         request = {
             # TODO: Consider what to do if text is too long.


### PR DESCRIPTION
* Add value error for empty comment string

Perspective API will throw a `COMMENT_EMPTY` 400 error if the comment string is empty or not set. This handles the exception before the request.

This should eliminate ambiguity about `comment.text` being `None` 