### PR TITLE
Add SUT response caching to simple_test_runner

### DIFF
--- a/newhelm/runners/simple_test_runner.py
+++ b/newhelm/runners/simple_test_runner.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional
 from tqdm import tqdm
 from newhelm.annotation import Annotation
 from newhelm.base_test import BasePromptResponseTest
+from newhelm.cache_helper import SUTResponseCache
 from newhelm.dependency_helper import FromSourceDependencyHelper
 from newhelm.record_init import get_initialization_record
 from newhelm.records import TestItemRecord, TestRecord
@@ -29,10 +30,11 @@ def run_prompt_response_test(
     # Ensure we can record what these objects are
     test_initialization = get_initialization_record(test)
     sut_initialization = get_initialization_record(sut)
+    test_data_path = os.path.join(data_dir, test.get_metadata().name)
 
     # This runner just records versions, it doesn't specify a required version.
     dependency_helper = FromSourceDependencyHelper(
-        os.path.join(data_dir, test.get_metadata().name),
+        test_data_path,
         test.get_dependencies(),
         required_versions={},
     )
@@ -44,16 +46,22 @@ def run_prompt_response_test(
         test_items = rng.sample(test_items, max_test_items)
     item_interactions: List[TestItemInteractions] = []
     desc = f"Collecting responses to {test_name} from {sut_name}"
-    for item in tqdm(test_items, desc=desc):
-        interactions = []
-        for prompt in item.prompts:
-            sut_request = sut.translate_request(prompt.prompt)
-            sut_response = sut.evaluate(sut_request)
-            response = sut.translate_response(prompt.prompt, sut_response)
-            interactions.append(PromptInteraction(prompt=prompt, response=response))
-        item_interactions.append(
-            TestItemInteractions(interactions=interactions, test_item=item)
-        )
+    with SUTResponseCache(
+        os.path.join(test_data_path, "cached_responses"), sut_name
+    ) as cache:
+        for item in tqdm(test_items, desc=desc):
+            interactions = []
+            for prompt in item.prompts:
+                sut_request = sut.translate_request(prompt.prompt)
+                sut_response = cache.get_cached_response(sut_request)
+                if sut_response is None:
+                    sut_response = sut.evaluate(sut_request)
+                    cache.update_cache(sut_request, sut_response)
+                response = sut.translate_response(prompt.prompt, sut_response)
+                interactions.append(PromptInteraction(prompt=prompt, response=response))
+            item_interactions.append(
+                TestItemInteractions(interactions=interactions, test_item=item)
+            )
     annotations_per_annotator: Dict[str, List[Annotation]] = {}
     keyed_annotators = test.get_annotators().items()
     for key, annotator in keyed_annotators:


### PR DESCRIPTION
Adding caching functionality to `simple_test_runner.py`, which was lost in a previous merge when `simple_benchmark_runner.py` was renamed.