### PR TITLE
Correctly handle the case where we run out of retries.

### DIFF
--- a/plugins/perspective_api/newhelm/annotators/perspective_api.py
+++ b/plugins/perspective_api/newhelm/annotators/perspective_api.py
@@ -161,6 +161,7 @@ def _batch_execute_requests(
 
     # Keep track of what requests have not yet successfully gotten a response
     needs_call = list(range(len(requests)))
+    retriable_errors: List[HttpError] = []
     for retry_count in range(num_retries + 1):
         if retry_count > 0:
             # Perform exponential backoff
@@ -182,11 +183,13 @@ def _batch_execute_requests(
         # Figure out which requests need to be tried again.
         next_round_needs_call: List[int] = []
         fatal_errors: List[HttpError] = []
+        retriable_errors = []
         for i in needs_call:
             error = errors[i]
             if error is not None:
                 if _is_retriable(error):
                     next_round_needs_call.append(i)
+                    retriable_errors.append(error)
                 else:
                     fatal_errors.append(error)
         if fatal_errors:
@@ -195,6 +198,9 @@ def _batch_execute_requests(
         if not next_round_needs_call:
             break
         needs_call = next_round_needs_call
+    if retriable_errors:
+        # We exhausted our retries, so raise the first as an example.
+        raise retriable_errors[0]
     return responses
 
 

--- a/plugins/perspective_api/tests/test_perspective_api.py
+++ b/plugins/perspective_api/tests/test_perspective_api.py
@@ -329,3 +329,31 @@ def test_perspective_api_multiple_completions_retriable_error():
             }
         },
     ]
+
+
+def test_perspective_api_no_retries_retriable_error():
+    interactions = [_make_interaction(["the text"])]
+    responses = [MockError(503)]
+    annotator = PerspectiveAPIAnnotator([ATTRIBUTE_TOXICITY], num_retries=0)
+    fake_client = FakeDiscoveryResource([responses])
+    annotator.client = fake_client
+
+    with pytest.raises(MockError) as err_info:
+        annotator.annotate_test_item(interactions)
+
+    err_text = str(err_info.value)
+    assert err_text == ("503")
+
+
+def test_perspective_api_continuous_retriable_error():
+    interactions = [_make_interaction(["the text"])]
+    batches = [[MockError(503)], [MockError(503)]]
+    annotator = PerspectiveAPIAnnotator([ATTRIBUTE_TOXICITY], num_retries=1)
+    fake_client = FakeDiscoveryResource(batches)
+    annotator.client = fake_client
+
+    with pytest.raises(MockError) as err_info:
+        annotator.annotate_test_item(interactions)
+
+    err_text = str(err_info.value)
+    assert err_text == ("503")


### PR DESCRIPTION
Previously we would return an empty dict for any request that got a retriable error on the final retry.