### PR TITLE
Switch from using HELM's PerspectiveAPI guide to the official docs.

### DIFF
--- a/plugins/perspective_api/newhelm/annotators/perspective_api.py
+++ b/plugins/perspective_api/newhelm/annotators/perspective_api.py
@@ -42,7 +42,8 @@ class PerspectiveAPIAnnotation(BaseModel):
 SECRETS.register(
     "perspective_api",
     "api_key",
-    "See https://crfm-helm.readthedocs.io/en/latest/benchmark/#perspective-api",
+    "First request access https://developers.perspectiveapi.com/s/docs-get-started?language=en_US"
+    " and then you can generate a key with https://developers.perspectiveapi.com/s/docs-enable-the-api?language=en_US",
 )
 
 


### PR DESCRIPTION
The HELM page didn't add much, and also talks about how to add the key to HELM's secrets management, which is different than how NewHELM does it.