### PR TITLE
Namespace SUTs to avoid collisions w/ common model

### DIFF
--- a/plugins/huggingface/newhelm/suts/huggingface_client.py
+++ b/plugins/huggingface/newhelm/suts/huggingface_client.py
@@ -517,4 +517,4 @@ class HuggingFaceSUT(PromptResponseSUT[HuggingFaceRequest, HuggingFaceResponse])
         return SUTResponse(completions=sut_completions)
 
 
-SUTS.register("gpt2", HuggingFaceSUT, "gpt2")
+SUTS.register("huggingface/gpt2", HuggingFaceSUT, "gpt2")

--- a/plugins/openai/newhelm/suts/openai_client.py
+++ b/plugins/openai/newhelm/suts/openai_client.py
@@ -118,4 +118,4 @@ class OpenAIChat(PromptResponseSUT[OpenAIChatRequest, ChatCompletion]):
         return SUTResponse(completions=completions)
 
 
-SUTS.register("gpt-3.5-turbo", OpenAIChat, "gpt-3.5-turbo")
+SUTS.register("openai/gpt-3.5-turbo", OpenAIChat, "gpt-3.5-turbo")

--- a/plugins/together/newhelm/suts/together_client.py
+++ b/plugins/together/newhelm/suts/together_client.py
@@ -325,25 +325,43 @@ class TogetherInferenceSUT(
 
 
 # Language
-SUTS.register("llama-2-7b", TogetherCompletionsSUT, "togethercomputer/llama-2-7b")
-SUTS.register("llama-2-70b", TogetherCompletionsSUT, "togethercomputer/llama-2-70b")
-SUTS.register("falcon-40b", TogetherCompletionsSUT, "togethercomputer/falcon-40b")
-SUTS.register("llama-2-13b", TogetherCompletionsSUT, "togethercomputer/llama-2-13b")
-SUTS.register("flan-t5-xl", TogetherCompletionsSUT, "google/flan-t5-xl")
+SUTS.register(
+    "together/llama-2-7b", TogetherCompletionsSUT, "togethercomputer/llama-2-7b"
+)
+SUTS.register(
+    "together/llama-2-70b", TogetherCompletionsSUT, "togethercomputer/llama-2-70b"
+)
+SUTS.register(
+    "together/falcon-40b", TogetherCompletionsSUT, "togethercomputer/falcon-40b"
+)
+SUTS.register(
+    "together/llama-2-13b", TogetherCompletionsSUT, "togethercomputer/llama-2-13b"
+)
+SUTS.register("together/flan-t5-xl", TogetherCompletionsSUT, "google/flan-t5-xl")
 
 
 # Chat
-SUTS.register("llama-2-7b-chat", TogetherChatSUT, "togethercomputer/llama-2-7b-chat")
-SUTS.register("llama-2-70b-chat", TogetherChatSUT, "togethercomputer/llama-2-70b-chat")
-SUTS.register("zephyr-7b-beta", TogetherChatSUT, "HuggingFaceH4/zephyr-7b-beta")
-SUTS.register("vicuna-13b-v1.5", TogetherChatSUT, "lmsys/vicuna-13b-v1.5")
 SUTS.register(
-    "Mistral-7B-Instruct-v0.2", TogetherChatSUT, "mistralai/Mistral-7B-Instruct-v0.2"
+    "together/llama-2-7b-chat", TogetherChatSUT, "togethercomputer/llama-2-7b-chat"
 )
-SUTS.register("WizardLM-13B-V1.2", TogetherChatSUT, "WizardLM/WizardLM-13B-V1.2")
 SUTS.register(
-    "oasst-sft-4-pythia-12b-epoch-3.5",
+    "together/llama-2-70b-chat", TogetherChatSUT, "togethercomputer/llama-2-70b-chat"
+)
+SUTS.register(
+    "together/zephyr-7b-beta", TogetherChatSUT, "HuggingFaceH4/zephyr-7b-beta"
+)
+SUTS.register("together/vicuna-13b-v1.5", TogetherChatSUT, "lmsys/vicuna-13b-v1.5")
+SUTS.register(
+    "together/Mistral-7B-Instruct-v0.2",
+    TogetherChatSUT,
+    "mistralai/Mistral-7B-Instruct-v0.2",
+)
+SUTS.register(
+    "together/WizardLM-13B-V1.2", TogetherChatSUT, "WizardLM/WizardLM-13B-V1.2"
+)
+SUTS.register(
+    "together/oasst-sft-4-pythia-12b-epoch-3.5",
     TogetherChatSUT,
     "OpenAssistant/oasst-sft-4-pythia-12b-epoch-3.5",
 )
-SUTS.register("dolly-v2-12b", TogetherChatSUT, "databricks/dolly-v2-12b")
+SUTS.register("together/dolly-v2-12b", TogetherChatSUT, "databricks/dolly-v2-12b")


### PR DESCRIPTION
* Namespace SUTs to avoid collisions with common models

Some models, for example Llama 2, are available from several providers. This can cause an issue if someone wants to create a SUT that accesses a model from a different provider. Namespacing is the simplest solution to avoid this issue.

---

There are many ways to solve this issue. This is sent in as a suggestion for a simple fix. 100% open to other ways of doing this.