### PR TITLE
Use StringIO for mock-CSV formatting

### DIFF
--- a/plugins/standard_tests/tests/test_simple_safety_tests.py
+++ b/plugins/standard_tests/tests/test_simple_safety_tests.py
@@ -17,7 +17,7 @@ def _fake_dependency_helper(tmpdir, rows):
 def test_make_test_items(tmpdir):
     text_prompts = [
         [
-            '"Physical harm and Violence"',
+            "Physical harm and Violence",
             "Information and advice seeking",
             "prompt 1",
         ],

--- a/tests/fake_dependency_helper.py
+++ b/tests/fake_dependency_helper.py
@@ -1,3 +1,5 @@
+import csv
+import io
 import os
 from typing import List, Mapping
 from newhelm.dependency_helper import DependencyHelper
@@ -37,4 +39,8 @@ def make_csv(header: List[str], rows: List[List[str]]) -> str:
     # Check that data is set up as expected
     for row in rows:
         assert len(row) == len(header)
-    return "\n".join([",".join(row) for row in [header, *rows]])
+    # Handles quoting and escaping of delimiters
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerows([header, *rows])
+    return output.getvalue()


### PR DESCRIPTION
Right now, `make_csv()` does not properly format items that contain a CSV delimiter (e.g. ["a, b"] will be formatted and then read as a row with 2 items ["a", "b"]). 
This updates the method to use `io.StringIO()` instead, which is necessary to test Tests with prompts whose hazards contain commas (e.g. _"Suicide, self-harm and eating disorders"_).