### PR TITLE
Create MissingSecretsFromConfig to guide adding secrets to config.

### DIFF
--- a/newhelm/config.py
+++ b/newhelm/config.py
@@ -1,10 +1,10 @@
 import os
 import shutil
-from typing import Mapping
+from typing import Mapping, Sequence
 import tomli
 from importlib import resources
 from newhelm import config_templates
-from newhelm.secret_values import RawSecrets
+from newhelm.secret_values import MissingSecretValues, RawSecrets
 
 
 DEFAULT_CONFIG_DIR = "config"
@@ -36,3 +36,36 @@ def load_secrets_from_config(path: str = SECRETS_PATH) -> RawSecrets:
             assert isinstance(key, str)
             assert isinstance(value, str)
     return data
+
+
+class MissingSecretsFromConfig(MissingSecretValues):
+    def __init__(self, missing: MissingSecretValues, config_path: str = SECRETS_PATH):
+        super().__init__(descriptions=missing.descriptions)
+        self.config_path = config_path
+
+    def __str__(self):
+        groups = {}
+        for secret in self.descriptions:
+            if secret.scope not in groups:
+                groups[secret.scope] = {}
+            groups[secret.scope][secret.key] = secret.instructions
+        message = f"To perform this run you need to add the following values "
+        message += f"to your secrets file '{self.config_path}':\n"
+        scope_displays = []
+        for scope, in_scope in sorted(groups.items()):
+            scope_display = f"[{scope}]\n"
+            for key, instruction in sorted(in_scope.items()):
+                scope_display += f"# {instruction}\n"
+                scope_display += f'{key}="<value>"\n'
+            scope_displays.append(scope_display)
+        message += "\n".join(scope_displays)
+        return message
+
+
+def raise_if_missing_from_config(
+    missing_values: Sequence[MissingSecretValues], config_path: str = SECRETS_PATH
+):
+    if not missing_values:
+        return
+    combined = MissingSecretValues.combine(missing_values)
+    raise MissingSecretsFromConfig(combined, config_path)

--- a/newhelm/config.py
+++ b/newhelm/config.py
@@ -39,6 +39,8 @@ def load_secrets_from_config(path: str = SECRETS_PATH) -> RawSecrets:
 
 
 class MissingSecretsFromConfig(MissingSecretValues):
+    """Exception showing how to add missing secrets to the config file."""
+
     def __init__(self, missing: MissingSecretValues, config_path: str = SECRETS_PATH):
         super().__init__(descriptions=missing.descriptions)
         self.config_path = config_path
@@ -65,6 +67,7 @@ class MissingSecretsFromConfig(MissingSecretValues):
 def raise_if_missing_from_config(
     missing_values: Sequence[MissingSecretValues], config_path: str = SECRETS_PATH
 ):
+    """If there are missing secrets, raise a MissingSecretsFromConfig exception."""
     if not missing_values:
         return
     combined = MissingSecretValues.combine(missing_values)

--- a/newhelm/runners/simple_test_runner_cli.py
+++ b/newhelm/runners/simple_test_runner_cli.py
@@ -8,7 +8,7 @@ from newhelm.command_line import (
     SUT_OPTION,
     newhelm_cli,
 )
-from newhelm.config import load_secrets_from_config
+from newhelm.config import load_secrets_from_config, raise_if_missing_from_config
 from newhelm.general import normalize_filename
 from newhelm.runners.simple_test_runner import (
     run_prompt_response_test,
@@ -57,9 +57,7 @@ def run_test(
     missing_secrets: List[MissingSecretValues] = []
     missing_secrets.extend(TESTS.get_missing_dependencies(test, secrets=secrets))
     missing_secrets.extend(SUTS.get_missing_dependencies(sut, secrets=secrets))
-    if missing_secrets:
-        # TODO Make this error explicitly say where to put the secrets
-        raise MissingSecretValues.combine(missing_secrets)
+    raise_if_missing_from_config(missing_secrets)
 
     test_obj = TESTS.make_instance(test, secrets=secrets)
     sut_obj = SUTS.make_instance(sut, secrets=secrets)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,9 +3,12 @@ import os
 import pytest
 from newhelm.config import (
     DEFAULT_SECRETS,
+    MissingSecretsFromConfig,
     load_secrets_from_config,
+    raise_if_missing_from_config,
     write_default_config,
 )
+from newhelm.secret_values import MissingSecretValues, SecretDescription
 
 
 def test_write_default_config_writes_files(tmpdir):
@@ -50,3 +53,62 @@ def test_load_secrets_from_config_bad_format(tmpdir):
         load_secrets_from_config(secrets_file)
     err_text = str(err_info.value)
     assert err_text == "All keys should be in a [scope]."
+
+
+def test_raise_if_missing_from_config_nothing_on_empty():
+    raise_if_missing_from_config([])
+
+
+def test_raise_if_missing_from_config_single():
+    secret = SecretDescription(
+        scope="some-scope", key="some-key", instructions="some-instructions"
+    )
+    missing = MissingSecretValues([secret])
+    with pytest.raises(MissingSecretsFromConfig) as err_info:
+        raise_if_missing_from_config([missing], config_path="some/path.toml")
+
+    assert (
+        str(err_info.value)
+        == """\
+To perform this run you need to add the following values to your secrets file 'some/path.toml':
+[some-scope]
+# some-instructions
+some-key="<value>"
+"""
+    )
+
+
+def test_raise_if_missing_from_config_combines():
+    scope1_key1 = SecretDescription(
+        scope="scope1", key="key1", instructions="instructions1"
+    )
+    scope1_key2 = SecretDescription(
+        scope="scope1", key="key2", instructions="instructions2"
+    )
+    scope2_key1 = SecretDescription(
+        scope="scope2", key="key1", instructions="instructions3"
+    )
+    missing = [
+        # Out of order
+        MissingSecretValues([scope1_key1]),
+        MissingSecretValues([scope2_key1]),
+        MissingSecretValues([scope1_key2]),
+    ]
+    with pytest.raises(MissingSecretsFromConfig) as err_info:
+        raise_if_missing_from_config(missing, config_path="some/path.toml")
+
+    assert (
+        str(err_info.value)
+        == """\
+To perform this run you need to add the following values to your secrets file 'some/path.toml':
+[scope1]
+# instructions1
+key1="<value>"
+# instructions2
+key2="<value>"
+
+[scope2]
+# instructions3
+key1="<value>"
+"""
+    )


### PR DESCRIPTION
When raised, this exception will display missing secrets in a format that you can copy and paste into your toml file.