### PR TITLE
Download files with only a google folder URL and the file name

### DIFF
--- a/newhelm/external_data.py
+++ b/newhelm/external_data.py
@@ -51,7 +51,7 @@ class GDriveData(ExternalData):
             if file.path == self.filename:
                 gdown.download(id=file.id, output=location)
                 return
-        raise Exception(
+        raise RuntimeError(
             f"Cannot find file with name {self.filename} in google drive folder {self.folder_url}"
         )
 

--- a/newhelm/external_data.py
+++ b/newhelm/external_data.py
@@ -37,22 +37,22 @@ class WebData(ExternalData):
 
 @dataclass(frozen=True, kw_only=True)
 class GDriveData(ExternalData):
-    """File downloaded using file's name and a google drive folder url."""
+    """File downloaded using a google drive folder url and a file's relative path to the folder."""
 
-    folder_url: str
-    filename: str
+    data_source: str
+    file_path: str
 
     def download(self, location):
         # Find file id needed to download the file.
         available_files = gdown.download_folder(
-            url=self.folder_url, skip_download=True, quiet=True
+            url=self.data_source, skip_download=True, quiet=True
         )
         for file in available_files:
-            if file.path == self.filename:
+            if file.path == self.file_path:
                 gdown.download(id=file.id, output=location)
                 return
         raise RuntimeError(
-            f"Cannot find file with name {self.filename} in google drive folder {self.folder_url}"
+            f"Cannot find file with name {self.file_path} in google drive folder {self.data_source}"
         )
 
 

--- a/newhelm/external_data.py
+++ b/newhelm/external_data.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Optional
 import shutil
 import urllib.request
+import gdown  # type: ignore
 
 from newhelm.data_packing import DataDecompressor, DataUnpacker
 from newhelm.general import UrlRetrieveProgressBar
@@ -31,6 +32,27 @@ class WebData(ExternalData):
             self.source_url,
             location,
             reporthook=UrlRetrieveProgressBar(self.source_url),
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class GDriveData(ExternalData):
+    """File downloaded using file's name and a google drive folder url."""
+
+    folder_url: str
+    filename: str
+
+    def download(self, location):
+        # Find file id needed to download the file.
+        available_files = gdown.download_folder(
+            url=self.folder_url, skip_download=True, quiet=True
+        )
+        for file in available_files:
+            if file.path == self.filename:
+                gdown.download(id=file.id, output=location)
+                return
+        raise Exception(
+            f"Cannot find file with name {self.filename} in google drive folder {self.folder_url}"
         )
 
 

--- a/plugins/standard_tests/newhelm/tests/safe.py
+++ b/plugins/standard_tests/newhelm/tests/safe.py
@@ -1,5 +1,4 @@
 import csv
-from pydantic import BaseModel
 from typing import List, Dict, Mapping
 
 from newhelm.annotators.llama_guard_annotator import (
@@ -10,7 +9,7 @@ from newhelm.aggregations import mean_of_measurement
 from newhelm.base_annotator import BaseAnnotator
 from newhelm.base_test import BasePromptResponseTest, Result, TestMetadata
 from newhelm.dependency_helper import DependencyHelper
-from newhelm.external_data import ExternalData, WebData
+from newhelm.external_data import ExternalData, GDriveData
 from newhelm.prompt import TextPrompt, SUTOptions
 from newhelm.record_init import record_init
 from newhelm.secret_values import InjectSecret
@@ -26,6 +25,8 @@ from newhelm.test_registry import TESTS
 
 HAZARDS_MAPPING = {
     "cae": "Child abuse and exploitation",
+    "cbr": "Chemical, biological, radioloigcal, nuclear and high-yield explosives weapons",
+    "gra": "Graphic depictions of hazards",
     "ssh": "Suicide, self-harm and eating disorders",
     "ter": "Terrorism",
 }
@@ -33,11 +34,11 @@ HAZARDS_MAPPING = {
 
 class SafeTest(BasePromptResponseTest):
     @record_init
-    def __init__(self, hazard: str, data_source: str, together_api_key: TogetherApiKey):
+    def __init__(self, hazard: str, folder_url: str, together_api_key: TogetherApiKey):
         assert hazard in HAZARDS_MAPPING, f"Invalid hazard type {hazard}."
         self.hazard = hazard
         self.hazard_name = HAZARDS_MAPPING[hazard]
-        self.data_source = data_source
+        self.folder_url = folder_url
         self.together_api_key = together_api_key
 
     def get_metadata(self) -> TestMetadata:
@@ -48,8 +49,9 @@ class SafeTest(BasePromptResponseTest):
 
     def get_dependencies(self) -> Mapping[str, ExternalData]:
         return {
-            "prompts_csv": WebData(
-                source_url=f"{self.data_source}/export?format=csv",
+            "prompts_csv": GDriveData(
+                folder_url=self.folder_url,
+                filename=f"mls_ais_wg_safe_{self.hazard}_hazardous.csv",
             ),
         }
 
@@ -63,8 +65,8 @@ class SafeTest(BasePromptResponseTest):
         with open(data_file, "r") as csvfile:
             reader = csv.DictReader(csvfile)
             for row in reader:
-                assert row["Hazard type"] == self.hazard_name
-                text = row["Direct prompt"].strip()
+                assert row["Hazard type shorthand"] == self.hazard
+                text = row["Prompt"].strip()
                 prompt = PromptWithContext(
                     prompt=TextPrompt(text=text, options=sut_options),
                     source_id=row["UID"],
@@ -90,26 +92,43 @@ class SafeTest(BasePromptResponseTest):
         return [Result(name="frac_safe", value=mean_of_measurement("is_safe", items))]
 
 
+GDRIVE_FOLDER = (
+    "https://drive.google.com/drive/folders/1uWhqBn_TpdFb2Lxr_9WXcLG2XyK5QMMa"
+)
 API_KEY_SECRET = InjectSecret(TogetherApiKey)
 
 TESTS.register(
     "safe-cae",
     SafeTest,
     "cae",
-    "https://docs.google.com/spreadsheets/d/14jF-vQEX9qrwKSUpeBD4j2CR8EzpTh7vGX6zVPmuDGI",
+    GDRIVE_FOLDER,
     API_KEY_SECRET,
 )
 TESTS.register(
     "safe-ssh",
     SafeTest,
     "ssh",
-    "https://docs.google.com/spreadsheets/d/1Xwbu2ObYMGfGsYjZ-rWzkwl5YNOM0K0Eqrqm9cQ3Bps",
+    GDRIVE_FOLDER,
     API_KEY_SECRET,
 )
 TESTS.register(
     "safe-ter",
     SafeTest,
     "ter",
-    "https://docs.google.com/spreadsheets/d/1entM7GuOjceuiz9wKZSUVT__fByIF9TXSXXh7KOGqY4",
+    GDRIVE_FOLDER,
+    API_KEY_SECRET,
+)
+TESTS.register(
+    "safe-cbr",
+    SafeTest,
+    "cbr",
+    GDRIVE_FOLDER,
+    API_KEY_SECRET,
+)
+TESTS.register(
+    "safe-gra",
+    SafeTest,
+    "gra",
+    GDRIVE_FOLDER,
     API_KEY_SECRET,
 )

--- a/plugins/standard_tests/newhelm/tests/safe.py
+++ b/plugins/standard_tests/newhelm/tests/safe.py
@@ -49,7 +49,7 @@ class SafeTest(BasePromptResponseTest):
 
     def get_dependencies(self) -> Mapping[str, ExternalData]:
         return {
-            "prompts_csv": GDriveData(
+            f"prompts_csv_{FOLDER_NAME}": GDriveData(
                 folder_url=self.folder_url,
                 filename=f"mls_ais_wg_safe_{self.hazard}_hazardous.csv",
             ),
@@ -61,7 +61,7 @@ class SafeTest(BasePromptResponseTest):
             temperature=0.01,
         )
         test_items: List[TestItem] = []
-        data_file = dependency_helper.get_local_path("prompts_csv")
+        data_file = dependency_helper.get_local_path(f"prompts_csv_{FOLDER_NAME}")
         with open(data_file, "r") as csvfile:
             reader = csv.DictReader(csvfile)
             for row in reader:
@@ -95,6 +95,7 @@ class SafeTest(BasePromptResponseTest):
 GDRIVE_FOLDER = (
     "https://drive.google.com/drive/folders/1uWhqBn_TpdFb2Lxr_9WXcLG2XyK5QMMa"
 )
+FOLDER_NAME = "data_08mar2024"
 API_KEY_SECRET = InjectSecret(TogetherApiKey)
 
 TESTS.register(

--- a/plugins/standard_tests/newhelm/tests/safe.py
+++ b/plugins/standard_tests/newhelm/tests/safe.py
@@ -34,11 +34,11 @@ HAZARDS_MAPPING = {
 
 class SafeTest(BasePromptResponseTest):
     @record_init
-    def __init__(self, hazard: str, folder_url: str, together_api_key: TogetherApiKey):
+    def __init__(self, hazard: str, folder_name: str, together_api_key: TogetherApiKey):
         assert hazard in HAZARDS_MAPPING, f"Invalid hazard type {hazard}."
         self.hazard = hazard
         self.hazard_name = HAZARDS_MAPPING[hazard]
-        self.folder_url = folder_url
+        self.folder_name = folder_name
         self.together_api_key = together_api_key
 
     def get_metadata(self) -> TestMetadata:
@@ -49,9 +49,9 @@ class SafeTest(BasePromptResponseTest):
 
     def get_dependencies(self) -> Mapping[str, ExternalData]:
         return {
-            f"prompts_csv_{FOLDER_NAME}": GDriveData(
-                folder_url=self.folder_url,
-                filename=f"mls_ais_wg_safe_{self.hazard}_hazardous.csv",
+            f"prompts_csv_{self.folder_name}": GDriveData(
+                data_source="https://drive.google.com/drive/folders/1FNpd9KQ1MvylgVNuWx7O0byWoFDyLBeS",
+                file_path=f"{self.folder_name}/mls_ais_wg_safe_{self.hazard}_hazardous.csv",
             ),
         }
 
@@ -61,7 +61,7 @@ class SafeTest(BasePromptResponseTest):
             temperature=0.01,
         )
         test_items: List[TestItem] = []
-        data_file = dependency_helper.get_local_path(f"prompts_csv_{FOLDER_NAME}")
+        data_file = dependency_helper.get_local_path(f"prompts_csv_{self.folder_name}")
         with open(data_file, "r") as csvfile:
             reader = csv.DictReader(csvfile)
             for row in reader:
@@ -92,9 +92,6 @@ class SafeTest(BasePromptResponseTest):
         return [Result(name="frac_safe", value=mean_of_measurement("is_safe", items))]
 
 
-GDRIVE_FOLDER = (
-    "https://drive.google.com/drive/folders/1uWhqBn_TpdFb2Lxr_9WXcLG2XyK5QMMa"
-)
 FOLDER_NAME = "data_08mar2024"
 API_KEY_SECRET = InjectSecret(TogetherApiKey)
 
@@ -102,34 +99,34 @@ TESTS.register(
     "safe-cae",
     SafeTest,
     "cae",
-    GDRIVE_FOLDER,
+    FOLDER_NAME,
     API_KEY_SECRET,
 )
 TESTS.register(
     "safe-ssh",
     SafeTest,
     "ssh",
-    GDRIVE_FOLDER,
+    FOLDER_NAME,
     API_KEY_SECRET,
 )
 TESTS.register(
     "safe-ter",
     SafeTest,
     "ter",
-    GDRIVE_FOLDER,
+    FOLDER_NAME,
     API_KEY_SECRET,
 )
 TESTS.register(
     "safe-cbr",
     SafeTest,
     "cbr",
-    GDRIVE_FOLDER,
+    FOLDER_NAME,
     API_KEY_SECRET,
 )
 TESTS.register(
     "safe-gra",
     SafeTest,
     "gra",
-    GDRIVE_FOLDER,
+    FOLDER_NAME,
     API_KEY_SECRET,
 )

--- a/plugins/standard_tests/tests/test_safe.py
+++ b/plugins/standard_tests/tests/test_safe.py
@@ -26,7 +26,7 @@ def test_make_test_items(tmpdir):
         ["prompt 1", hazard, "id1"],
         ["prompt 2", hazard, "id2"],
     ]
-    test = SafeTest(hazard, "url", TogetherApiKey("some-value"))
+    test = SafeTest(hazard, FOLDER_NAME, TogetherApiKey("some-value"))
     dependency_helper = _fake_dependency_helper(tmpdir, text_prompts)
     test_items = test.make_test_items(dependency_helper)
 
@@ -43,7 +43,7 @@ def test_make_test_items(tmpdir):
 def test_hazard_mismatch_exception(tmpdir):
     """An error is raised if the test encounters an item in the dataset with a different hazard."""
     hazard1, hazard2 = HAZARDS_LIST[:2]
-    test = SafeTest(hazard1, "url", TogetherApiKey("some-value"))
+    test = SafeTest(hazard1, FOLDER_NAME, TogetherApiKey("some-value"))
     dependency_helper = _fake_dependency_helper(tmpdir, [["prompt", hazard2, "id"]])
     with pytest.raises(AssertionError):
         test.make_test_items(dependency_helper)
@@ -53,7 +53,7 @@ def test_different_hazards(tmpdir):
     """Checks that all tests will produce identical TestItems for datasets that only differ in the hazard_name column."""
     items = []
     for hazard in HAZARDS_LIST:
-        test = SafeTest(hazard, "url", TogetherApiKey("some-value"))
+        test = SafeTest(hazard, FOLDER_NAME, TogetherApiKey("some-value"))
         dependency_helper = _fake_dependency_helper(tmpdir, [["prompt", hazard, "id"]])
         items.append(test.make_test_items(dependency_helper)[0])
     assert all(item == items[0] for item in items)
@@ -61,7 +61,7 @@ def test_different_hazards(tmpdir):
 
 def test_unknown_hazard_exception():
     with pytest.raises(AssertionError, match="Invalid hazard type"):
-        SafeTest("New Hazard", "url", TogetherApiKey("some-value"))
+        SafeTest("New Hazard", FOLDER_NAME, TogetherApiKey("some-value"))
 
 
 def test_aggregate_measurements():
@@ -74,6 +74,6 @@ def test_aggregate_measurements():
         MeasuredTestItem(test_item=dummy_item, measurements={"is_safe": 1.0}),
         MeasuredTestItem(test_item=dummy_item, measurements={"is_safe": 1.0}),
     ]
-    test = SafeTest(HAZARDS_LIST[0], "url", TogetherApiKey("some-value"))
+    test = SafeTest(HAZARDS_LIST[0], FOLDER_NAME, TogetherApiKey("some-value"))
     results = test.aggregate_measurements(measured_test_items)
     assert results == [Result(name="frac_safe", value=2.0 / 3.0)]

--- a/plugins/standard_tests/tests/test_safe.py
+++ b/plugins/standard_tests/tests/test_safe.py
@@ -2,7 +2,7 @@ import pytest
 
 from newhelm.base_test import Result
 from newhelm.prompt import TextPrompt
-from newhelm.tests.safe import SafeTest, HAZARDS_MAPPING
+from newhelm.tests.safe import SafeTest, HAZARDS_MAPPING, FOLDER_NAME
 from newhelm.single_turn_prompt_response import (
     MeasuredTestItem,
     TestItem,
@@ -17,7 +17,7 @@ HAZARDS_LIST = list(HAZARDS_MAPPING.keys())
 def _fake_dependency_helper(tmpdir, rows):
     csv_header = ["Prompt", "Hazard type shorthand", "UID"]
     csv_text = make_csv(csv_header, rows)
-    return FakeDependencyHelper(tmpdir, {"prompts_csv": csv_text})
+    return FakeDependencyHelper(tmpdir, {f"prompts_csv_{FOLDER_NAME}": csv_text})
 
 
 def test_make_test_items(tmpdir):

--- a/plugins/standard_tests/tests/test_safe.py
+++ b/plugins/standard_tests/tests/test_safe.py
@@ -11,62 +11,50 @@ from newhelm.single_turn_prompt_response import (
 from newhelm.suts.together_client import TogetherApiKey
 from tests.fake_dependency_helper import FakeDependencyHelper, make_csv
 
-HAZARD = "cae"
+HAZARDS_LIST = list(HAZARDS_MAPPING.keys())
 
 
 def _fake_dependency_helper(tmpdir, rows):
-    csv_header = ["Direct prompt", "Hazard type", "UID"]
+    csv_header = ["Prompt", "Hazard type shorthand", "UID"]
     csv_text = make_csv(csv_header, rows)
     return FakeDependencyHelper(tmpdir, {"prompts_csv": csv_text})
 
 
-def _make_test_item(text, hazard, prompt_uid="") -> TestItem:
-    return TestItem(
-        prompts=[PromptWithContext(prompt=TextPrompt(text=text), source_id=prompt_uid)]
-    )
-
-
 def test_make_test_items(tmpdir):
-    hazard_name = HAZARDS_MAPPING[HAZARD]
+    hazard = HAZARDS_LIST[0]
     text_prompts = [
-        ["prompt 1", hazard_name, "id1"],
-        ["prompt 2", hazard_name, "id2"],
+        ["prompt 1", hazard, "id1"],
+        ["prompt 2", hazard, "id2"],
     ]
-    test = SafeTest(HAZARD, "url", TogetherApiKey("some-value"))
+    test = SafeTest(hazard, "url", TogetherApiKey("some-value"))
     dependency_helper = _fake_dependency_helper(tmpdir, text_prompts)
     test_items = test.make_test_items(dependency_helper)
 
     assert len(test_items) == 2
     assert all([len(item.prompts) == 1 for item in test_items])
-    expected_item_1 = _make_test_item("prompt 1", hazard_name, "id1")
-    expected_item_2 = _make_test_item("prompt 2", hazard_name, "id2")
-    # Ignore the SUTOptions attribute in the prompts
-    get_prompts = lambda item: list(map(lambda x: x.prompt.text, item.prompts))
-    assert get_prompts(test_items[0]) == get_prompts(expected_item_1)
-    assert get_prompts(test_items[1]) == get_prompts(expected_item_2)
-    assert test_items[0].context == expected_item_1.context
-    assert test_items[1].context == expected_item_2.context
+    # Check prompt, while ignoring sut_options
+    assert test_items[0].prompts[0].prompt.text == "prompt 1"
+    assert test_items[1].prompts[0].prompt.text == "prompt 2"
+    # Check source_id
+    assert test_items[0].prompts[0].source_id == "id1"
+    assert test_items[1].prompts[0].source_id == "id2"
 
 
 def test_hazard_mismatch_exception(tmpdir):
     """An error is raised if the test encounters an item in the dataset with a different hazard."""
-    hazard1, hazard2 = list(HAZARDS_MAPPING.keys())[:2]
+    hazard1, hazard2 = HAZARDS_LIST[:2]
     test = SafeTest(hazard1, "url", TogetherApiKey("some-value"))
-    dependency_helper = _fake_dependency_helper(
-        tmpdir, [["prompt", HAZARDS_MAPPING[hazard2], "id"]]
-    )
+    dependency_helper = _fake_dependency_helper(tmpdir, [["prompt", hazard2, "id"]])
     with pytest.raises(AssertionError):
         test.make_test_items(dependency_helper)
 
 
 def test_different_hazards(tmpdir):
-    """Checks that the tests will produce identical TestItems for datasets that only differ in the hazard_name column."""
+    """Checks that all tests will produce identical TestItems for datasets that only differ in the hazard_name column."""
     items = []
-    for hazard in HAZARDS_MAPPING.keys():
+    for hazard in HAZARDS_LIST:
         test = SafeTest(hazard, "url", TogetherApiKey("some-value"))
-        dependency_helper = _fake_dependency_helper(
-            tmpdir, [["prompt", HAZARDS_MAPPING[hazard], "id"]]
-        )
+        dependency_helper = _fake_dependency_helper(tmpdir, [["prompt", hazard, "id"]])
         items.append(test.make_test_items(dependency_helper)[0])
     assert all(item == items[0] for item in items)
 
@@ -77,13 +65,15 @@ def test_unknown_hazard_exception():
 
 
 def test_aggregate_measurements():
-    dummy_item = _make_test_item("prompt", HAZARDS_MAPPING[HAZARD])
+    dummy_item = TestItem(
+        prompts=[PromptWithContext(prompt=TextPrompt(text="prompt"), source_id="id")]
+    )
     # 2 safe, 1 unsafe
     measured_test_items = [
         MeasuredTestItem(test_item=dummy_item, measurements={"is_safe": 0.0}),
         MeasuredTestItem(test_item=dummy_item, measurements={"is_safe": 1.0}),
         MeasuredTestItem(test_item=dummy_item, measurements={"is_safe": 1.0}),
     ]
-    test = SafeTest(HAZARD, "url", TogetherApiKey("some-value"))
+    test = SafeTest(HAZARDS_LIST[0], "url", TogetherApiKey("some-value"))
     results = test.aggregate_measurements(measured_test_items)
     assert results == [Result(name="frac_safe", value=2.0 / 3.0)]

--- a/poetry.lock
+++ b/poetry.lock
@@ -204,6 +204,32 @@ url = "https://us-central1-python.pkg.dev/ai-safety-dev/aisafety-pypi/simple"
 reference = "mlcommons"
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.12.3"
+description = "Screen-scraping library"
+optional = false
+python-versions = ">=3.6.0"
+files = [
+    {file = "beautifulsoup4-4.12.3-py3-none-any.whl", hash = "sha256:b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed"},
+    {file = "beautifulsoup4-4.12.3.tar.gz", hash = "sha256:74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051"},
+]
+
+[package.dependencies]
+soupsieve = ">1.2"
+
+[package.extras]
+cchardet = ["cchardet"]
+chardet = ["chardet"]
+charset-normalizer = ["charset-normalizer"]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[package.source]
+type = "legacy"
+url = "https://us-central1-python.pkg.dev/ai-safety-dev/aisafety-pypi/simple"
+reference = "mlcommons"
+
+[[package]]
 name = "black"
 version = "23.12.1"
 description = "The uncompromising code formatter."
@@ -274,7 +300,7 @@ reference = "mlcommons"
 name = "certifi"
 version = "2024.2.2"
 description = "Python package for providing Mozilla's CA Bundle."
-optional = true
+optional = false
 python-versions = ">=3.6"
 files = [
     {file = "certifi-2024.2.2-py3-none-any.whl", hash = "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"},
@@ -359,7 +385,7 @@ reference = "mlcommons"
 name = "charset-normalizer"
 version = "3.3.2"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-optional = true
+optional = false
 python-versions = ">=3.7.0"
 files = [
     {file = "charset-normalizer-3.3.2.tar.gz", hash = "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"},
@@ -496,7 +522,7 @@ reference = "mlcommons"
 
 [[package]]
 name = "demo-plugin"
-version = "0.1.7"
+version = "0.2.1"
 description = ""
 optional = true
 python-versions = "^3.10"
@@ -546,7 +572,7 @@ reference = "mlcommons"
 name = "filelock"
 version = "3.13.1"
 description = "A platform independent file lock."
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "filelock-3.13.1-py3-none-any.whl", hash = "sha256:57dbda9b35157b05fb3e58ee91448612eb674172fab98ee235ccb0b5bee19a1c"},
@@ -688,6 +714,31 @@ sftp = ["paramiko"]
 smb = ["smbprotocol"]
 ssh = ["paramiko"]
 tqdm = ["tqdm"]
+
+[package.source]
+type = "legacy"
+url = "https://us-central1-python.pkg.dev/ai-safety-dev/aisafety-pypi/simple"
+reference = "mlcommons"
+
+[[package]]
+name = "gdown"
+version = "5.1.0"
+description = "Google Drive Public File/Folder Downloader"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "gdown-5.1.0-py3-none-any.whl", hash = "sha256:421530fd238fa15d41ba43219a79fdc28efe8ac11022173abad333701b77de2c"},
+    {file = "gdown-5.1.0.tar.gz", hash = "sha256:550a72dc5ca2819fe4bcc15d80d05d7c98c0b90e57256254b77d0256b9df4683"},
+]
+
+[package.dependencies]
+beautifulsoup4 = "*"
+filelock = "*"
+requests = {version = "*", extras = ["socks"]}
+tqdm = "*"
+
+[package.extras]
+test = ["build", "mypy", "pytest", "pytest-xdist", "ruff", "twine", "types-requests"]
 
 [package.source]
 type = "legacy"
@@ -946,7 +997,7 @@ reference = "mlcommons"
 name = "idna"
 version = "3.6"
 description = "Internationalized Domain Names in Applications (IDNA)"
-optional = true
+optional = false
 python-versions = ">=3.5"
 files = [
     {file = "idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"},
@@ -1289,7 +1340,7 @@ reference = "mlcommons"
 
 [[package]]
 name = "newhelm-huggingface"
-version = "0.1.7"
+version = "0.2.1"
 description = ""
 optional = true
 python-versions = "^3.10"
@@ -1306,7 +1357,7 @@ url = "plugins/huggingface"
 
 [[package]]
 name = "newhelm-openai"
-version = "0.1.7"
+version = "0.2.1"
 description = ""
 optional = true
 python-versions = "^3.10"
@@ -1322,7 +1373,7 @@ url = "plugins/openai"
 
 [[package]]
 name = "newhelm-together"
-version = "0.1.7"
+version = "0.2.1"
 description = ""
 optional = true
 python-versions = "^3.10"
@@ -1650,7 +1701,7 @@ reference = "mlcommons"
 
 [[package]]
 name = "perspective-api"
-version = "0.1.7"
+version = "0.2.1"
 description = ""
 optional = true
 python-versions = "^3.10"
@@ -1920,6 +1971,23 @@ url = "https://us-central1-python.pkg.dev/ai-safety-dev/aisafety-pypi/simple"
 reference = "mlcommons"
 
 [[package]]
+name = "pysocks"
+version = "1.7.1"
+description = "A Python SOCKS client module. See https://github.com/Anorov/PySocks for more information."
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "PySocks-1.7.1-py27-none-any.whl", hash = "sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299"},
+    {file = "PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5"},
+    {file = "PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0"},
+]
+
+[package.source]
+type = "legacy"
+url = "https://us-central1-python.pkg.dev/ai-safety-dev/aisafety-pypi/simple"
+reference = "mlcommons"
+
+[[package]]
 name = "pytest"
 version = "7.4.4"
 description = "pytest: simple powerful testing with Python"
@@ -2163,7 +2231,7 @@ reference = "mlcommons"
 name = "requests"
 version = "2.31.0"
 description = "Python HTTP for Humans."
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
@@ -2174,6 +2242,7 @@ files = [
 certifi = ">=2017.4.17"
 charset-normalizer = ">=2,<4"
 idna = ">=2.5,<4"
+PySocks = {version = ">=1.5.6,<1.5.7 || >1.5.7", optional = true, markers = "extra == \"socks\""}
 urllib3 = ">=1.21.1,<3"
 
 [package.extras]
@@ -2358,6 +2427,22 @@ url = "https://us-central1-python.pkg.dev/ai-safety-dev/aisafety-pypi/simple"
 reference = "mlcommons"
 
 [[package]]
+name = "soupsieve"
+version = "2.5"
+description = "A modern CSS selector implementation for Beautiful Soup."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "soupsieve-2.5-py3-none-any.whl", hash = "sha256:eaa337ff55a1579b6549dc679565eac1e3d000563bcb1c8ab0d0fefbc0c2cdc7"},
+    {file = "soupsieve-2.5.tar.gz", hash = "sha256:5663d5a7b3bfaeee0bc4372e7fc48f9cff4940b3eec54a6451cc5299f1097690"},
+]
+
+[package.source]
+type = "legacy"
+url = "https://us-central1-python.pkg.dev/ai-safety-dev/aisafety-pypi/simple"
+reference = "mlcommons"
+
+[[package]]
 name = "sqlitedict"
 version = "2.1.0"
 description = "Persistent dict in Python, backed up by sqlite3 and pickle, multithread-safe."
@@ -2390,7 +2475,7 @@ reference = "mlcommons"
 
 [[package]]
 name = "standard-tests"
-version = "0.1.7"
+version = "0.2.1"
 description = ""
 optional = true
 python-versions = "^3.10"
@@ -2902,7 +2987,7 @@ reference = "mlcommons"
 name = "urllib3"
 version = "2.2.1"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "urllib3-2.2.1-py3-none-any.whl", hash = "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"},
@@ -3104,4 +3189,4 @@ together = ["newhelm_together"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.11"
-content-hash = "6225a3b880bd80c2024f35d7c09773d7457695d0d2082322c7efe907573604c2"
+content-hash = "34ef3fcadc7969e15ac9890c240d3eb770b66b5beac41ea78af8a64470fdf01a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ tqdm = ">=4.66.1"
 types-tqdm = "^4.66.0.0"
 pydantic = "^2.6.0"
 sqlitedict = "^2.1.0"
+gdown = ">=5.1.0"
 demo_plugin = {version = "*", optional = true}
 standard_tests = {version = "*", optional = true}
 newhelm_openai = {version = "*", optional = true}

--- a/tests/test_external_data.py
+++ b/tests/test_external_data.py
@@ -1,5 +1,9 @@
+from collections import namedtuple
 from unittest.mock import ANY
-from newhelm.external_data import WebData, LocalData
+import pytest
+from newhelm.external_data import WebData, GDriveData, LocalData
+
+GDriveFileToDownload = namedtuple("GDriveFileToDownload", ("id", "path"))
 
 
 def test_web_data_download(mocker):
@@ -9,6 +13,54 @@ def test_web_data_download(mocker):
     mock_download.assert_called_once_with(
         "http://example.com", "test.tgz", reporthook=ANY
     )
+
+
+def test_gdrive_data_download(mocker):
+    mock_download_folder = mocker.patch(
+        "gdown.download_folder",
+        return_value=[GDriveFileToDownload("file_id", "file.csv")],
+    )
+    mock_download_file = mocker.patch("gdown.download")
+    gdrive_data = GDriveData(folder_url="http://example_drive.com", filename="file.csv")
+    gdrive_data.download("test.tgz")
+    mock_download_folder.assert_called_once_with(
+        url="http://example_drive.com", skip_download=True, quiet=True
+    )
+    mock_download_file.assert_called_once_with(id="file_id", output="test.tgz")
+
+
+def test_gdrive_correct_file_download(mocker):
+    """Checks that correct file is downloaded if multiple files exist in the folder."""
+    mock_download_folder = mocker.patch(
+        "gdown.download_folder",
+        return_value=[
+            GDriveFileToDownload("file_id1", "different_file.csv"),
+            GDriveFileToDownload("file_id2", "file.txt"),
+            GDriveFileToDownload("file_id3", "file.csv"),
+        ],
+    )
+    mock_download_file = mocker.patch("gdown.download")
+    gdrive_data = GDriveData(folder_url="http://example_drive.com", filename="file.csv")
+    gdrive_data.download("test.tgz")
+    mock_download_folder.assert_called_once_with(
+        url="http://example_drive.com", skip_download=True, quiet=True
+    )
+    mock_download_file.assert_called_once_with(id="file_id3", output="test.tgz")
+
+
+def test_gdrive_nonexistent_filename(mocker):
+    """Throws exception when the folder does not contain any files with the desired filename."""
+    mock_download_folder = mocker.patch(
+        "gdown.download_folder",
+        return_value=[
+            GDriveFileToDownload("file_id1", "different_file.csv"),
+            GDriveFileToDownload("file_id2", "file.txt"),
+        ],
+    )
+    mock_download_file = mocker.patch("gdown.download")
+    gdrive_data = GDriveData(folder_url="http://example_drive.com", filename="file.csv")
+    with pytest.raises(Exception, match="Cannot find file"):
+        gdrive_data.download("test.tgz")
 
 
 def test_local_data_download(mocker):

--- a/tests/test_external_data.py
+++ b/tests/test_external_data.py
@@ -59,7 +59,7 @@ def test_gdrive_nonexistent_filename(mocker):
     )
     mock_download_file = mocker.patch("gdown.download")
     gdrive_data = GDriveData(folder_url="http://example_drive.com", filename="file.csv")
-    with pytest.raises(Exception, match="Cannot find file"):
+    with pytest.raises(RuntimeError, match="Cannot find file"):
         gdrive_data.download("test.tgz")
 
 

--- a/tests/test_external_data.py
+++ b/tests/test_external_data.py
@@ -21,7 +21,9 @@ def test_gdrive_data_download(mocker):
         return_value=[GDriveFileToDownload("file_id", "file.csv")],
     )
     mock_download_file = mocker.patch("gdown.download")
-    gdrive_data = GDriveData(folder_url="http://example_drive.com", filename="file.csv")
+    gdrive_data = GDriveData(
+        data_source="http://example_drive.com", file_path="file.csv"
+    )
     gdrive_data.download("test.tgz")
     mock_download_folder.assert_called_once_with(
         url="http://example_drive.com", skip_download=True, quiet=True
@@ -40,12 +42,30 @@ def test_gdrive_correct_file_download(mocker):
         ],
     )
     mock_download_file = mocker.patch("gdown.download")
-    gdrive_data = GDriveData(folder_url="http://example_drive.com", filename="file.csv")
+    gdrive_data = GDriveData(
+        data_source="http://example_drive.com", file_path="file.csv"
+    )
     gdrive_data.download("test.tgz")
     mock_download_folder.assert_called_once_with(
         url="http://example_drive.com", skip_download=True, quiet=True
     )
     mock_download_file.assert_called_once_with(id="file_id3", output="test.tgz")
+
+
+def test_gdrive_download_file_with_relative_path(mocker):
+    mock_download_folder = mocker.patch(
+        "gdown.download_folder",
+        return_value=[
+            GDriveFileToDownload("file_id", "file.csv"),
+            GDriveFileToDownload("nested_file_id", "sub_folder/file.csv"),
+        ],
+    )
+    mock_download_file = mocker.patch("gdown.download")
+    gdrive_data = GDriveData(
+        data_source="http://example_drive.com", file_path="sub_folder/file.csv"
+    )
+    gdrive_data.download("test.tgz")
+    mock_download_file.assert_called_once_with(id="nested_file_id", output="test.tgz")
 
 
 def test_gdrive_nonexistent_filename(mocker):
@@ -58,7 +78,9 @@ def test_gdrive_nonexistent_filename(mocker):
         ],
     )
     mock_download_file = mocker.patch("gdown.download")
-    gdrive_data = GDriveData(folder_url="http://example_drive.com", filename="file.csv")
+    gdrive_data = GDriveData(
+        data_source="http://example_drive.com", file_path="file.csv"
+    )
     with pytest.raises(RuntimeError, match="Cannot find file"):
         gdrive_data.download("test.tgz")
 


### PR DESCRIPTION
This PR tackles two issues:
1. **Updates the data file sources** to a new folder created by the tests group ([data_08mar2024](https://drive.google.com/drive/folders/1uWhqBn_TpdFb2Lxr_9WXcLG2XyK5QMMa)).
    * New hazards  `cbr` (Chemical, biological, radioloigcal, nuclear and high-yield explosives weapons) and
    `gra` (Graphic depictions of hazards).
    * These new files are CSVs instead of google spreadsheets.
2.  **Create a new ExternalData type `GDriveData`.**
    * Before, each test had be initialized with a different url pointing to the their respective spreadsheet. Having to copy the links to each new file every time the working group releases a new set of updated files is tedious, especially as the number of tests grow.
    * To address this issue, I created the `GDriveData` class, which only requires the folder URL and desired filename. It uses the `gdown` library to extract the file ID for a hazard without needing a file-specific URL or file ID. Also, gdown is the only option to do this without any credentials or API keys.

Now, each time the the working group releases a new folder of CSVs, the only thing we have to update is the `GDRIVE_FOLDER` url constant. And register tests for any new hazards.