### PR TITLE
Unify on "class_name" as the serialized fully qualified class name.

### DIFF
--- a/newhelm/dependency_injection.py
+++ b/newhelm/dependency_injection.py
@@ -39,7 +39,7 @@ def _replace_with_injected(value, secrets: RawSecrets):
     if isinstance(value, Injector):
         return value.inject(secrets)
     if isinstance(value, SerializedSecret):
-        cls = get_class(value.module, value.qual_name)
+        cls = get_class(value.module, value.class_name)
         assert issubclass(cls, BaseSecret)
         return cls.make(secrets)
     return value

--- a/newhelm/record_init.py
+++ b/newhelm/record_init.py
@@ -14,13 +14,13 @@ class InitializationRecord(BaseModel):
     """Holds data sufficient to reconstruct an object."""
 
     module: str
-    qual_name: str
+    class_name: str
     args: List[Any]
     kwargs: Mapping[str, Any]
 
     def recreate_object(self, *, secrets: RawSecrets = {}):
         """Redoes the init call from this record."""
-        cls = getattr(importlib.import_module(self.module), self.qual_name)
+        cls = getattr(importlib.import_module(self.module), self.class_name)
         args, kwargs = inject_dependencies(self.args, self.kwargs, secrets=secrets)
         return cls(*args, **kwargs)
 
@@ -36,7 +36,7 @@ def record_init(init):
         if not hasattr(self, "_initialization_record"):
             self._initialization_record = InitializationRecord(
                 module=self.__class__.__module__,
-                qual_name=self.__class__.__qualname__,
+                class_name=self.__class__.__qualname__,
                 args=record_args,
                 kwargs=record_kwargs,
             )

--- a/newhelm/secret_values.py
+++ b/newhelm/secret_values.py
@@ -47,13 +47,13 @@ class SerializedSecret(BaseModel):
     """Hold a pointer to the secret class in a serializable form."""
 
     module: str
-    qual_name: str
+    class_name: str
 
     @staticmethod
     def serialize(secret: BaseSecret):
         return SerializedSecret(
             module=secret.__class__.__module__,
-            qual_name=secret.__class__.__qualname__,
+            class_name=secret.__class__.__qualname__,
         )
 
 

--- a/tests/test_record_init.py
+++ b/tests/test_record_init.py
@@ -49,7 +49,7 @@ def test_record_init_all_positional():
     obj = SomeClass(1, 2, 3)
     assert obj.total == 6
     assert obj._initialization_record == InitializationRecord(
-        module="test_record_init", qual_name="SomeClass", args=[1, 2, 3], kwargs={}
+        module="test_record_init", class_name="SomeClass", args=[1, 2, 3], kwargs={}
     )
 
     returned = obj._initialization_record.recreate_object()
@@ -61,7 +61,7 @@ def test_record_init_all_kwarg():
     assert obj.total == 6
     assert obj._initialization_record == InitializationRecord(
         module="test_record_init",
-        qual_name="SomeClass",
+        class_name="SomeClass",
         args=[],
         kwargs={"x": 1, "y": 2, "z": 3},
     )
@@ -76,7 +76,7 @@ def test_record_init_mix_positional_and_kwarg():
     assert obj.total == 6
     assert obj._initialization_record == InitializationRecord(
         module="test_record_init",
-        qual_name="SomeClass",
+        class_name="SomeClass",
         args=[1],
         kwargs={"y": 2, "z": 3},
     )
@@ -91,7 +91,7 @@ def test_record_init_defaults():
     assert obj._initialization_record == InitializationRecord(
         # Note the default isn't recorded
         module="test_record_init",
-        qual_name="ClassWithDefaults",
+        class_name="ClassWithDefaults",
         args=[],
         kwargs={},
     )
@@ -106,7 +106,7 @@ def test_record_init_defaults_overwritten():
     assert obj._initialization_record == InitializationRecord(
         # Note the default isn't recorded
         module="test_record_init",
-        qual_name="ClassWithDefaults",
+        class_name="ClassWithDefaults",
         args=["foo"],
         kwargs={},
     )
@@ -118,7 +118,7 @@ def test_record_init_defaults_overwritten():
 def test_parent_and_child_recorded_init():
     obj = ChildWithInit(1, 2)
     assert obj._initialization_record == InitializationRecord(
-        module="test_record_init", qual_name="ChildWithInit", args=[1, 2], kwargs={}
+        module="test_record_init", class_name="ChildWithInit", args=[1, 2], kwargs={}
     )
     returned = obj._initialization_record.recreate_object()
     assert returned.one == obj.one
@@ -129,7 +129,7 @@ def test_parent_and_child_recorded_init():
 def test_child_no_recorded_init():
     obj = ChildNoInit(1)
     assert obj._initialization_record == InitializationRecord(
-        module="test_record_init", qual_name="ChildNoInit", args=[1], kwargs={}
+        module="test_record_init", class_name="ChildNoInit", args=[1], kwargs={}
     )
     returned = obj._initialization_record.recreate_object()
     assert returned.one == obj.one
@@ -139,7 +139,7 @@ def test_child_no_recorded_init():
 def test_get_record():
     obj = SomeClass(1, 2, 3)
     assert get_initialization_record(obj) == InitializationRecord(
-        module="test_record_init", qual_name="SomeClass", args=[1, 2, 3], kwargs={}
+        module="test_record_init", class_name="SomeClass", args=[1, 2, 3], kwargs={}
     )
 
 
@@ -165,11 +165,11 @@ def test_uses_secrets_arg():
     obj = UsesSecrets(1, FakeRequiredSecret("some-value"))
     assert obj._initialization_record == InitializationRecord(
         module="test_record_init",
-        qual_name="UsesSecrets",
+        class_name="UsesSecrets",
         args=[
             1,
             SerializedSecret(
-                module="tests.fake_secrets", qual_name="FakeRequiredSecret"
+                module="tests.fake_secrets", class_name="FakeRequiredSecret"
             ),
         ],
         kwargs={},
@@ -184,12 +184,12 @@ def test_uses_secrets_kwarg():
     obj = UsesSecrets(arg1=1, arg2=FakeRequiredSecret("some-value"))
     assert obj._initialization_record == InitializationRecord(
         module="test_record_init",
-        qual_name="UsesSecrets",
+        class_name="UsesSecrets",
         args=[],
         kwargs={
             "arg1": 1,
             "arg2": SerializedSecret(
-                module="tests.fake_secrets", qual_name="FakeRequiredSecret"
+                module="tests.fake_secrets", class_name="FakeRequiredSecret"
             ),
         },
     )

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -42,12 +42,12 @@ def test_serialize_test_record():
         ),
         test_name="some-test",
         test_initialization=InitializationRecord(
-            module="some-module", qual_name="test-class", args=[], kwargs={}
+            module="some-module", class_name="test-class", args=[], kwargs={}
         ),
         dependency_versions={"d1": "v1"},
         sut_name="some-sut",
         sut_initialization=InitializationRecord(
-            module="another-module", qual_name="sut-class", args=["an-arg"], kwargs={}
+            module="another-module", class_name="sut-class", args=["an-arg"], kwargs={}
         ),
         test_item_records=[
             TestItemRecord(
@@ -82,7 +82,7 @@ def test_serialize_test_record():
   "test_name": "some-test",
   "test_initialization": {
     "module": "some-module",
-    "qual_name": "test-class",
+    "class_name": "test-class",
     "args": [],
     "kwargs": {}
   },
@@ -92,7 +92,7 @@ def test_serialize_test_record():
   "sut_name": "some-sut",
   "sut_initialization": {
     "module": "another-module",
-    "qual_name": "sut-class",
+    "class_name": "sut-class",
     "args": [
       "an-arg"
     ],

--- a/tests/test_secret_values.py
+++ b/tests/test_secret_values.py
@@ -99,9 +99,9 @@ def test_serialize_secret():
     original = SomeRequiredSecret("some-value")
     serialized = SerializedSecret.serialize(original)
     assert serialized == SerializedSecret(
-        module="test_secret_values", qual_name="SomeRequiredSecret"
+        module="test_secret_values", class_name="SomeRequiredSecret"
     )
-    returned = get_class(serialized.module, serialized.qual_name)
+    returned = get_class(serialized.module, serialized.class_name)
     assert returned.description() == SecretDescription(
         scope="some-scope", key="some-key", instructions="some-instructions"
     )


### PR DESCRIPTION
Before this PR, TypedData called it class_name, but InitializationRecord and SerializedSecret called it "qual_name". Since that json is likely to be read by users, I think "class_name" is more clear about what it is.

This breaks our ability to read JSON for those two objects written before this PR, but as I don't think we do that yet this should be fine.