### PR TITLE
Fix persisting empty folder from GDriveData

### DIFF
--- a/newhelm/external_data.py
+++ b/newhelm/external_data.py
@@ -1,7 +1,9 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Optional
+import os
 import shutil
+import tempfile
 import urllib.request
 import gdown  # type: ignore
 
@@ -43,10 +45,12 @@ class GDriveData(ExternalData):
     file_path: str
 
     def download(self, location):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Empty folder downloaded to tmpdir
+            available_files = gdown.download_folder(
+                url=self.data_source, skip_download=True, quiet=True, output=tmpdir
+            )
         # Find file id needed to download the file.
-        available_files = gdown.download_folder(
-            url=self.data_source, skip_download=True, quiet=True
-        )
         for file in available_files:
             if file.path == self.file_path:
                 gdown.download(id=file.id, output=location)

--- a/tests/test_external_data.py
+++ b/tests/test_external_data.py
@@ -26,7 +26,7 @@ def test_gdrive_data_download(mocker):
     )
     gdrive_data.download("test.tgz")
     mock_download_folder.assert_called_once_with(
-        url="http://example_drive.com", skip_download=True, quiet=True
+        url="http://example_drive.com", skip_download=True, quiet=ANY, output=ANY
     )
     mock_download_file.assert_called_once_with(id="file_id", output="test.tgz")
 
@@ -47,7 +47,7 @@ def test_gdrive_correct_file_download(mocker):
     )
     gdrive_data.download("test.tgz")
     mock_download_folder.assert_called_once_with(
-        url="http://example_drive.com", skip_download=True, quiet=True
+        url="http://example_drive.com", skip_download=True, quiet=ANY, output=ANY
     )
     mock_download_file.assert_called_once_with(id="file_id3", output="test.tgz")
 
@@ -83,6 +83,7 @@ def test_gdrive_nonexistent_filename(mocker):
     )
     with pytest.raises(RuntimeError, match="Cannot find file"):
         gdrive_data.download("test.tgz")
+    mock_download_file.assert_not_called()
 
 
 def test_local_data_download(mocker):


### PR DESCRIPTION
Even when `skip_download=True`, gdown still creates an empty folder in its `download_folder()` method. This PR prevents that empty folder from persisting at the root directory.