### PR TITLE
Fix issue where max_test_items=0 resulted in doing all items.

### DIFF
--- a/newhelm/runners/simple_test_runner.py
+++ b/newhelm/runners/simple_test_runner.py
@@ -27,7 +27,7 @@ def run_prompt_response_test(
     sut: PromptResponseSUT,
     data_dir: str,
     max_test_items: Optional[int] = None,
-    use_caching: Optional[bool] = True,
+    use_caching: bool = True,
     disable_progress_bar: bool = False,
 ) -> TestRecord:
     """Demonstration for how to run a single Test on a single SUT, all calls serial."""
@@ -62,10 +62,12 @@ def run_prompt_response_test(
     )
 
     test_items = test.make_test_items(dependency_helper)
-    if max_test_items and max_test_items < len(test_items):
-        rng = random.Random()
-        rng.seed(0)
-        test_items = rng.sample(test_items, max_test_items)
+    if max_test_items is not None:
+        assert max_test_items > 0, f"Cannot run a test using {max_test_items}."
+        if max_test_items < len(test_items):
+            rng = random.Random()
+            rng.seed(0)
+            test_items = rng.sample(test_items, max_test_items)
     test_item_records = []
     measured_test_items = []
     desc = f"Processing TestItems for test={test_name} sut={sut_name}"

--- a/tests/runners/test_simple_test_runner.py
+++ b/tests/runners/test_simple_test_runner.py
@@ -166,6 +166,25 @@ def test_run_prompt_response_test_max_test_items(tmpdir):
     assert record.result.to_instance() == FakeTestResult(count_test_items=3.0)
 
 
+def test_run_prompt_response_test_max_test_items_zero(tmpdir):
+    # Lots of test items
+    test_items = [fake_test_item(str(i)) for i in range(100)]
+    with pytest.raises(AssertionError) as err_info:
+        run_prompt_response_test(
+            "some-test",
+            FakeTest(
+                test_items=test_items,
+                annotators={"some-annotator": FakeAnnotator()},
+                measurement={},
+            ),
+            "some-sut",
+            FakeSUT(),
+            tmpdir,
+            max_test_items=0,
+        )
+    assert str(err_info.value) == "Cannot run a test using 0."
+
+
 def test_run_prompt_response_test_sut_exception(tmpdir):
     item_1 = fake_test_item("1")
     fake_measurement = {"some-measurement": 0.5}


### PR DESCRIPTION
This is because both None and 0 are treated as false in python. While I'm here, also remove the unnecessary (but not error causing) Optional is use_caching.