### PR TITLE
Have Tests and SUTs know their UIDs.

### DIFF
--- a/demo_plugin/newhelm/suts/demo_01_yes_no_sut.py
+++ b/demo_plugin/newhelm/suts/demo_01_yes_no_sut.py
@@ -39,4 +39,4 @@ class DemoYesNoSUT(PromptResponseSUT[DemoYesNoRequest, DemoYesNoResponse]):
         return SUTResponse(completions=[SUTCompletion(text=response.text)])
 
 
-SUTS.register("demo_yes_no", DemoYesNoSUT)
+SUTS.register(DemoYesNoSUT, "demo_yes_no")

--- a/demo_plugin/newhelm/suts/demo_02_secrets_and_options_sut.py
+++ b/demo_plugin/newhelm/suts/demo_02_secrets_and_options_sut.py
@@ -38,12 +38,13 @@ class DemoRandomWords(
     """SUT that returns random words based on the input prompt."""
 
     @record_init
-    def __init__(self, api_key: DemoApiKey):
+    def __init__(self, uid: str, api_key: DemoApiKey):
         """Secrets should be passed into the constructor.
 
         The @record_init decorator is used to make sure the framework can
         reconstruct your SUT later if someone wants to reproduce existing results.
         """
+        super().__init__(uid)
         self.api_key = api_key.value
         # Use lazy initialization of the client so we don't have to do a lot of work
         # until its actually needed.
@@ -98,7 +99,7 @@ def _words_in_chat(prompt: ChatPrompt) -> str:
     return " ".join(words)
 
 
-SUTS.register("demo_random_words", DemoRandomWords, InjectSecret(DemoApiKey))
+SUTS.register(DemoRandomWords, "demo_random_words", InjectSecret(DemoApiKey))
 
 # Everything below here is the implementation of the RandomWordsClient,
 # which you obviously wouldn't need to do for for an existing SUT.

--- a/demo_plugin/newhelm/suts/demo_03_sut_with_args.py
+++ b/demo_plugin/newhelm/suts/demo_03_sut_with_args.py
@@ -21,7 +21,8 @@ class DemoConstantSUT(PromptResponseSUT[DemoConstantRequest, DemoConstantRespons
     """This SUT allows you to configure the response it will always give."""
 
     @record_init
-    def __init__(self, response_text: str):
+    def __init__(self, uid: str, response_text: str):
+        super().__init__(uid)
         self.response_text = response_text
 
     def translate_text_prompt(self, prompt: TextPrompt) -> DemoConstantRequest:
@@ -43,8 +44,8 @@ class DemoConstantSUT(PromptResponseSUT[DemoConstantRequest, DemoConstantRespons
 
 
 # Everything after the class name gets passed to the class.
-SUTS.register("demo_always_angry", DemoConstantSUT, "I hate you!")
+SUTS.register(DemoConstantSUT, "demo_always_angry", "I hate you!")
 # You can use kwargs if you want.
 SUTS.register(
-    "demo_always_sorry", DemoConstantSUT, response_text="Sorry, I can't help with that."
+    DemoConstantSUT, "demo_always_sorry", response_text="Sorry, I can't help with that."
 )

--- a/demo_plugin/newhelm/tests/demo_01_simple_qa_test.py
+++ b/demo_plugin/newhelm/tests/demo_01_simple_qa_test.py
@@ -74,4 +74,4 @@ class DemoSimpleQATest(BasePromptResponseTest):
         return {"gave_safe_answer_rate": mean_of_measurement("gave_safe_answer", items)}
 
 
-TESTS.register("demo_01", DemoSimpleQATest)
+TESTS.register(DemoSimpleQATest, "demo_01")

--- a/demo_plugin/newhelm/tests/demo_02_unpacking_dependency_test.py
+++ b/demo_plugin/newhelm/tests/demo_02_unpacking_dependency_test.py
@@ -82,4 +82,4 @@ class DemoUnpackingDependencyTest(BasePromptResponseTest):
         return {"gave_safe_answer_rate": mean_of_measurement("gave_safe_answer", items)}
 
 
-TESTS.register("demo_02", DemoUnpackingDependencyTest)
+TESTS.register(DemoUnpackingDependencyTest, "demo_02")

--- a/demo_plugin/newhelm/tests/demo_03_paired_prompts_test.py
+++ b/demo_plugin/newhelm/tests/demo_03_paired_prompts_test.py
@@ -120,4 +120,4 @@ class DemoPairedPromptsTest(BasePromptResponseTest):
         }
 
 
-TESTS.register("demo_03", DemoPairedPromptsTest)
+TESTS.register(DemoPairedPromptsTest, "demo_03")

--- a/demo_plugin/newhelm/tests/demo_04_using_annotation_test.py
+++ b/demo_plugin/newhelm/tests/demo_04_using_annotation_test.py
@@ -30,7 +30,8 @@ class DemoUsingAnnotationTest(BasePromptResponseTest):
         return {}
 
     @record_init
-    def __init__(self, num_samples=10, seed=0):
+    def __init__(self, uid: str, num_samples=10, seed=0):
+        super().__init__(uid)
         self.num_samples = num_samples
         self.seed = seed
 
@@ -74,4 +75,4 @@ class DemoUsingAnnotationTest(BasePromptResponseTest):
         return {"bad_rate": mean_of_measurement("is_bad", items)}
 
 
-TESTS.register("demo_04", DemoUsingAnnotationTest)
+TESTS.register(DemoUsingAnnotationTest, "demo_04")

--- a/docs/tutorial_suts.md
+++ b/docs/tutorial_suts.md
@@ -77,7 +77,7 @@ Some notes on `translate_response`:
 Finally, to make our new SUT discoverable, we can add it to the registry, giving it a unique key:
 
 ```py
-SUTS.register("demo_yes_no", DemoYesNoSUT)
+SUTS.register(DemoYesNoSUT, "demo_yes_no")
 ```
 
 With our SUT [installed](plugins.md), we can run it manually with `run-sut`:
@@ -122,7 +122,8 @@ Secrets should be passed into a SUT's `__init__` function:
 
 ```py
 @record_init
-def __init__(self, api_key: DemoApiKey):
+def __init__(self, uid: str api_key: DemoApiKey):
+    super().__init__(uid)
     self.api_key = api_key.value
 ```
 
@@ -133,7 +134,7 @@ The `.value` property on `RequiredSecret` returns the `str` secret itself, so we
 Finally, when we register an instance of the SUT, we need to specify which secret we need:
 
 ```py
-SUTS.register("demo_random_words", DemoRandomWords, InjectSecret(DemoApiKey))
+SUTS.register(DemoRandomWords, "demo_random_words", InjectSecret(DemoApiKey))
 ```
 
 When running from the command line, NewHELM will (by default) read the `config/secrets.toml` file and look for the value matching the `DemoApiKey`.
@@ -178,7 +179,8 @@ Many APIs allow you to interact with different models as easily as switching a r
 ```py
 class DemoConstantSUT(PromptResponseSUT[DemoConstantRequest, DemoConstantResponse]):
     @record_init
-    def __init__(self, response_text: str):
+    def __init__(self, uid: str, response_text: str):
+        super().__init__(uid)
         self.response_text = response_text
 ```
 
@@ -186,9 +188,9 @@ We can then register multiple version of this SUT:
 
 ```py
 # Everything after the class name gets passed to the class.
-SUTS.register("demo_always_angry", DemoConstantSUT, "I hate you!")
+SUTS.register(DemoConstantSUT, "demo_always_angry", "I hate you!")
 # You can use kwargs if you want.
-SUTS.register("demo_always_sorry", DemoConstantSUT, response_text="Sorry, I can't help with that.")
+SUTS.register(DemoConstantSUT, "demo_always_sorry", response_text="Sorry, I can't help with that.")
 ```
 
 Reminder: when using NewHELM as a library you can always skip the registration step and construct SUTs directly. Registration is only needed to make something accessible via command line.

--- a/docs/tutorial_tests.md
+++ b/docs/tutorial_tests.md
@@ -41,7 +41,7 @@ We can then use one of the provided [aggregation functions](../newhelm/aggregati
 Finally, to make our new Test discoverable, we can add it to the registry, giving it a unique key:
 
 ```py
-TESTS.register("demo_01", DemoSimpleQATest)
+TESTS.register(DemoSimpleQATest, "demo_01")
 ```
 
 With our Test [installed](plugins.md), we should now be able to run our Test against any SUT in NewHELM!

--- a/newhelm/base_test.py
+++ b/newhelm/base_test.py
@@ -6,12 +6,12 @@ from newhelm.base_annotator import BaseAnnotator
 from newhelm.dependency_helper import DependencyHelper
 from newhelm.external_data import ExternalData
 
-from newhelm.record_init import record_init
 from newhelm.single_turn_prompt_response import (
     TestItemAnnotations,
     MeasuredTestItem,
     TestItem,
 )
+from newhelm.tracked_object import TrackedObject
 from newhelm.typed_data import Typeable, TypedData
 
 
@@ -26,22 +26,12 @@ class TestMetadata(BaseModel):
     __test__ = False
 
 
-class BaseTest(ABC):
+class BaseTest(TrackedObject):
     """This is the placeholder base class for all tests."""
 
     @abstractmethod
     def get_metadata(self) -> TestMetadata:
         """Return a description of the test."""
-        pass
-
-    @record_init
-    def __init__(self):
-        """Ensure all Tests default to recording their initialization.
-
-        We want to ensure all Tests record their init to allow us to reconstruct
-        their behavior later. If a Test needs to define its own __init__ that is fine,
-        it should just include the decorator.
-        """
         pass
 
 

--- a/newhelm/instance_factory.py
+++ b/newhelm/instance_factory.py
@@ -4,24 +4,26 @@ from typing import Any, Dict, Generic, List, Sequence, Tuple, Type, TypeVar
 from newhelm.dependency_injection import inject_dependencies
 
 from newhelm.secret_values import MissingSecretValues, RawSecrets
+from newhelm.tracked_object import TrackedObject
 
 
-_T = TypeVar("_T")
+_T = TypeVar("_T", bound=TrackedObject)
 
 
 @dataclass(frozen=True)
 class FactoryEntry(Generic[_T]):
     cls: Type[_T]
+    uid: str
     args: Tuple[Any]
     kwargs: Dict[str, Any]
 
     def __str__(self):
         """Return a string representation of the entry."""
-        return f"{self.cls.__name__}(args={self.args}, kwargs={self.kwargs})"
+        return f"{self.cls.__name__}(uid={self.uid}, args={self.args}, kwargs={self.kwargs})"
 
     def make_instance(self, *, secrets: RawSecrets) -> _T:
         args, kwargs = inject_dependencies(self.args, self.kwargs, secrets=secrets)
-        return self.cls(*args, **kwargs)  # type: ignore [call-arg]
+        return self.cls(self.uid, *args, **kwargs)  # type: ignore [call-arg]
 
     def get_missing_dependencies(
         self, *, secrets: RawSecrets
@@ -41,36 +43,36 @@ class InstanceFactory(Generic[_T]):
         self._lookup: Dict[str, FactoryEntry[_T]] = {}
         self.lock = threading.Lock()
 
-    def register(self, key: str, cls: Type[_T], *args, **kwargs):
+    def register(self, cls: Type[_T], uid: str, *args, **kwargs):
         """Add value to the registry, ensuring it has a unique key."""
         with self.lock:
-            previous = self._lookup.get(key)
+            previous = self._lookup.get(uid)
             assert previous is None, (
-                f"Factory already contains {key} set to "
+                f"Factory already contains {uid} set to "
                 f"{previous.cls.__name__}(args={previous.args}, "
                 f"kwargs={previous.kwargs})."
             )
-            self._lookup[key] = FactoryEntry[_T](cls, args, kwargs)
+            self._lookup[uid] = FactoryEntry[_T](cls, uid, args, kwargs)
 
-    def make_instance(self, key: str, *, secrets: RawSecrets) -> _T:
+    def make_instance(self, uid: str, *, secrets: RawSecrets) -> _T:
         """Create an instance using the  class and arguments passed to register, raise exception if missing."""
-        entry = self._get_entry(key)
+        entry = self._get_entry(uid)
         return entry.make_instance(secrets=secrets)
 
     def get_missing_dependencies(
-        self, key: str, *, secrets: RawSecrets
+        self, uid: str, *, secrets: RawSecrets
     ) -> Sequence[MissingSecretValues]:
-        entry = self._get_entry(key)
+        entry = self._get_entry(uid)
         return entry.get_missing_dependencies(secrets=secrets)
 
-    def _get_entry(self, key: str) -> FactoryEntry:
+    def _get_entry(self, uid: str) -> FactoryEntry:
         with self.lock:
             entry: FactoryEntry
             try:
-                entry = self._lookup[key]
+                entry = self._lookup[uid]
             except KeyError:
-                known_keys = list(self._lookup.keys())
-                raise KeyError(f"No registration for {key}. Known keys: {known_keys}")
+                known_uids = list(self._lookup.keys())
+                raise KeyError(f"No registration for {uid}. Known uids: {known_uids}")
         return entry
 
     def items(self) -> List[Tuple[str, FactoryEntry[_T]]]:

--- a/newhelm/runners/simple_test_runner.py
+++ b/newhelm/runners/simple_test_runner.py
@@ -21,9 +21,7 @@ from newhelm.sut import PromptResponseSUT
 
 
 def run_prompt_response_test(
-    test_name: str,
     test: BasePromptResponseTest,
-    sut_name: str,
     sut: PromptResponseSUT,
     data_dir: str,
     max_test_items: Optional[int] = None,
@@ -40,7 +38,7 @@ def run_prompt_response_test(
     sut_cache: BaseCache
     if use_caching:
         directory = os.path.join(test_data_path, "cached_responses")
-        sut_cache = SqlDictCache(directory, sut_name)
+        sut_cache = SqlDictCache(directory, sut.uid)
     else:
         sut_cache = NoCache()
     annotators = []
@@ -70,7 +68,7 @@ def run_prompt_response_test(
             test_items = rng.sample(test_items, max_test_items)
     test_item_records = []
     measured_test_items = []
-    desc = f"Processing TestItems for test={test_name} sut={sut_name}"
+    desc = f"Processing TestItems for test={test.uid} sut={sut.uid}"
     for test_item in tqdm(test_items, desc=desc, disable=disable_progress_bar):
         test_item_record = _process_test_item(
             test_item, test, sut, sut_cache, annotators
@@ -86,10 +84,10 @@ def run_prompt_response_test(
         test.aggregate_measurements(measured_test_items)
     )
     return TestRecord(
-        test_name=test_name,
+        test_name=test.uid,
         test_initialization=test_initialization,
         dependency_versions=dependency_helper.versions_used(),
-        sut_name=sut_name,
+        sut_name=sut.uid,
         sut_initialization=sut_initialization,
         test_item_records=test_item_records,
         result=test_result,

--- a/newhelm/runners/simple_test_runner_cli.py
+++ b/newhelm/runners/simple_test_runner_cli.py
@@ -72,9 +72,7 @@ def run_test(
             "output", normalize_filename(f"record_for_{test}_{sut}.json")
         )
     test_record = run_prompt_response_test(
-        test,
         test_obj,
-        sut,
         sut_obj,
         data_dir,
         max_test_items,

--- a/newhelm/sut.py
+++ b/newhelm/sut.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 from newhelm.prompt import ChatPrompt, TextPrompt
 from newhelm.record_init import record_init
+from newhelm.tracked_object import TrackedObject
 
 RequestType = TypeVar("RequestType")
 ResponseType = TypeVar("ResponseType")
@@ -22,18 +23,8 @@ class SUTResponse(BaseModel):
     completions: List[SUTCompletion]
 
 
-class SUT(ABC):
+class SUT(TrackedObject):
     """Base class for all SUTs. There is no guaranteed interface between SUTs, so no methods here."""
-
-    @record_init
-    def __init__(self):
-        """Ensure all SUTs default to recording their initialization.
-
-        We want to ensure all SUTs record their init to allow us to reconstruct
-        their behavior later. If a SUT needs to define its own __init__ that is fine,
-        it should just include the decorator.
-        """
-        pass
 
 
 class PromptResponseSUT(SUT, ABC, Generic[RequestType, ResponseType]):

--- a/newhelm/tracked_object.py
+++ b/newhelm/tracked_object.py
@@ -1,0 +1,10 @@
+from abc import ABC
+from newhelm.record_init import record_init
+
+
+class TrackedObject(ABC):
+    """Base class for objects that have a UID."""
+
+    @record_init
+    def __init__(self, uid):
+        self.uid = uid

--- a/plugins/huggingface/newhelm/suts/huggingface_client.py
+++ b/plugins/huggingface/newhelm/suts/huggingface_client.py
@@ -264,8 +264,13 @@ class HuggingFaceSUT(PromptResponseSUT[HuggingFaceRequest, HuggingFaceResponse])
 
     @record_init
     def __init__(
-        self, pretrained_model_name_or_path: str, token: HuggingFaceToken, **kwargs
+        self,
+        uid: str,
+        pretrained_model_name_or_path: str,
+        token: HuggingFaceToken,
+        **kwargs,
     ):
+        super().__init__(uid)
         if torch.cuda.is_available():
             self.device: str = "cuda:0"
         else:
@@ -542,4 +547,4 @@ class HuggingFaceSUT(PromptResponseSUT[HuggingFaceRequest, HuggingFaceResponse])
         return SUTResponse(completions=sut_completions)
 
 
-SUTS.register("gpt2", HuggingFaceSUT, "gpt2", InjectSecret(HuggingFaceToken))
+SUTS.register(HuggingFaceSUT, "gpt2", "gpt2", InjectSecret(HuggingFaceToken))

--- a/plugins/openai/newhelm/annotators/openai_compliance_annotator.py
+++ b/plugins/openai/newhelm/annotators/openai_compliance_annotator.py
@@ -39,7 +39,9 @@ class OpenAIComplianceAnnotator(BaseAnnotator[ComplianceAnnotation]):
             assert (
                 openai_api_key is not None and openai_api_org_id is not None
             ), "Must either pass sut or openai secrets."
-            self.model = OpenAIChat(_MODEL_NAME, openai_api_key, openai_api_org_id)
+            self.model = OpenAIChat(
+                "annotator", _MODEL_NAME, openai_api_key, openai_api_org_id
+            )
         self.formatter = _default_formatter if formatter is None else formatter
         self.decoder = _DEFAULT_MAPPING if decoder is None else decoder
 

--- a/plugins/openai/newhelm/suts/openai_client.py
+++ b/plugins/openai/newhelm/suts/openai_client.py
@@ -83,7 +83,10 @@ class OpenAIChat(PromptResponseSUT[OpenAIChatRequest, ChatCompletion]):
     """
 
     @record_init
-    def __init__(self, model: str, api_key: OpenAIApiKey, org_id: OpenAIOrgId):
+    def __init__(
+        self, uid: str, model: str, api_key: OpenAIApiKey, org_id: OpenAIOrgId
+    ):
+        super().__init__(uid)
         self.model = model
         self.client: Optional[OpenAI] = None
         self.api_key = api_key.value
@@ -141,8 +144,8 @@ class OpenAIChat(PromptResponseSUT[OpenAIChatRequest, ChatCompletion]):
 
 
 SUTS.register(
-    "gpt-3.5-turbo",
     OpenAIChat,
+    "gpt-3.5-turbo",
     "gpt-3.5-turbo",
     InjectSecret(OpenAIApiKey),
     InjectSecret(OpenAIOrgId),

--- a/plugins/openai/tests/test_openai_client.py
+++ b/plugins/openai/tests/test_openai_client.py
@@ -11,7 +11,10 @@ from newhelm.prompt import TextPrompt
 
 def test_openai_chat_translate_request():
     client = OpenAIChat(
-        model="some-model", api_key=OpenAIApiKey("some-value"), org_id=OpenAIOrgId(None)
+        uid="test-model",
+        model="some-model",
+        api_key=OpenAIApiKey("some-value"),
+        org_id=OpenAIOrgId(None),
     )
     prompt = TextPrompt(text="some-text")
     request = client.translate_text_prompt(prompt)

--- a/plugins/standard_tests/newhelm/tests/bbq.py
+++ b/plugins/standard_tests/newhelm/tests/bbq.py
@@ -126,7 +126,8 @@ class BBQ(BasePromptResponseTest):
         return dependencies
 
     @record_init
-    def __init__(self, subject: str = "all", num_in_context_examples=5):
+    def __init__(self, uid: str, subject: str = "all", num_in_context_examples=5):
+        super().__init__(uid)
         self.subject = subject
         self.num_in_context_examples = num_in_context_examples
 
@@ -471,4 +472,4 @@ class BBQ(BasePromptResponseTest):
         )
 
 
-TESTS.register("bbq", BBQ)
+TESTS.register(BBQ, "bbq")

--- a/plugins/standard_tests/newhelm/tests/real_toxicity_prompts.py
+++ b/plugins/standard_tests/newhelm/tests/real_toxicity_prompts.py
@@ -51,7 +51,8 @@ class RealToxicityPrompts(BasePromptResponseTest):
     """
 
     @record_init
-    def __init__(self, perspective_developer_key: PerspectiveDeveloperKey):
+    def __init__(self, uid: str, perspective_developer_key: PerspectiveDeveloperKey):
+        super().__init__(uid)
         self.perspective_developer_key = perspective_developer_key
 
     def get_metadata(self) -> TestMetadata:
@@ -155,7 +156,7 @@ class RealToxicityPrompts(BasePromptResponseTest):
 
 
 TESTS.register(
-    "real_toxicity_prompts",
     RealToxicityPrompts,
+    "real_toxicity_prompts",
     InjectSecret(PerspectiveDeveloperKey),
 )

--- a/plugins/standard_tests/newhelm/tests/safe.py
+++ b/plugins/standard_tests/newhelm/tests/safe.py
@@ -41,11 +41,13 @@ class SafeTest(BasePromptResponseTest):
     @record_init
     def __init__(
         self,
+        uid: str,
         hazard: str,
         folder_name: str,
         together_api_key: TogetherApiKey,
         benign_prompts: bool = False,
     ):
+        super().__init__(uid)
         assert hazard in HAZARDS_MAPPING, f"Invalid hazard type {hazard}."
         self.hazard = hazard
         self.hazard_name = HAZARDS_MAPPING[hazard]
@@ -110,60 +112,60 @@ FOLDER_NAME = "data_08mar2024"
 API_KEY_SECRET = InjectSecret(TogetherApiKey)
 # Hazardous Prompts
 TESTS.register(
-    "safe-cae",
     SafeTest,
+    "safe-cae",
     "cae",
     FOLDER_NAME,
     API_KEY_SECRET,
 )
 TESTS.register(
-    "safe-ssh",
     SafeTest,
+    "safe-ssh",
     "ssh",
     FOLDER_NAME,
     API_KEY_SECRET,
 )
 TESTS.register(
-    "safe-ter",
     SafeTest,
+    "safe-ter",
     "ter",
     FOLDER_NAME,
     API_KEY_SECRET,
 )
 TESTS.register(
-    "safe-cbr",
     SafeTest,
+    "safe-cbr",
     "cbr",
     FOLDER_NAME,
     API_KEY_SECRET,
 )
 TESTS.register(
-    "safe-gra",
     SafeTest,
+    "safe-gra",
     "gra",
     FOLDER_NAME,
     API_KEY_SECRET,
 )
 # Benign prompts
 TESTS.register(
-    "safe-cae-benign",
     SafeTest,
+    "safe-cae-benign",
     "cae",
     FOLDER_NAME,
     API_KEY_SECRET,
     benign_prompts=True,
 )
 TESTS.register(
-    "safe-ssh-benign",
     SafeTest,
+    "safe-ssh-benign",
     "ssh",
     FOLDER_NAME,
     API_KEY_SECRET,
     benign_prompts=True,
 )
 TESTS.register(
-    "safe-ter-benign",
     SafeTest,
+    "safe-ter-benign",
     "ter",
     FOLDER_NAME,
     API_KEY_SECRET,

--- a/plugins/standard_tests/newhelm/tests/simple_safety_tests.py
+++ b/plugins/standard_tests/newhelm/tests/simple_safety_tests.py
@@ -64,7 +64,8 @@ class SimpleSafetyTests(BasePromptResponseTest):
     """
 
     @record_init
-    def __init__(self, together_api_key: TogetherApiKey):
+    def __init__(self, uid: str, together_api_key: TogetherApiKey):
+        super().__init__(uid)
         self.together_api_key = together_api_key
 
     def get_metadata(self) -> TestMetadata:
@@ -141,4 +142,4 @@ class SimpleSafetyTests(BasePromptResponseTest):
         return SimpleSafetyTestResult(overall=overall, by_harm=by_harm)
 
 
-TESTS.register("simple_safety_tests", SimpleSafetyTests, InjectSecret(TogetherApiKey))
+TESTS.register(SimpleSafetyTests, "simple_safety_tests", InjectSecret(TogetherApiKey))

--- a/plugins/standard_tests/newhelm/tests/xstest.py
+++ b/plugins/standard_tests/newhelm/tests/xstest.py
@@ -50,7 +50,10 @@ class XSTest(BasePromptResponseTest):
     """
 
     @record_init
-    def __init__(self, openai_api_key: OpenAIApiKey, openai_api_org_id: OpenAIOrgId):
+    def __init__(
+        self, uid: str, openai_api_key: OpenAIApiKey, openai_api_org_id: OpenAIOrgId
+    ):
+        super().__init__(uid)
         self.openai_api_key = openai_api_key
         self.openai_api_org_id = openai_api_org_id
 
@@ -257,4 +260,4 @@ class StrMatchAnnotator(BaseAnnotator[ComplianceAnnotation]):
             return "Full Compliance"
 
 
-TESTS.register("xstest", XSTest, InjectSecret(OpenAIApiKey), InjectSecret(OpenAIOrgId))
+TESTS.register(XSTest, "xstest", InjectSecret(OpenAIApiKey), InjectSecret(OpenAIOrgId))

--- a/plugins/standard_tests/tests/test_safe.py
+++ b/plugins/standard_tests/tests/test_safe.py
@@ -25,7 +25,7 @@ def test_make_test_items(tmpdir):
         ["prompt 1", hazard, "id1"],
         ["prompt 2", hazard, "id2"],
     ]
-    test = SafeTest(hazard, FOLDER_NAME, TogetherApiKey("some-value"))
+    test = SafeTest("uid", hazard, FOLDER_NAME, TogetherApiKey("some-value"))
     dependency_helper = _fake_dependency_helper(tmpdir, text_prompts)
     test_items = test.make_test_items(dependency_helper)
 
@@ -42,7 +42,7 @@ def test_make_test_items(tmpdir):
 def test_hazard_mismatch_exception(tmpdir):
     """An error is raised if the test encounters an item in the dataset with a different hazard."""
     hazard1, hazard2 = HAZARDS_LIST[:2]
-    test = SafeTest(hazard1, FOLDER_NAME, TogetherApiKey("some-value"))
+    test = SafeTest("uid", hazard1, FOLDER_NAME, TogetherApiKey("some-value"))
     dependency_helper = _fake_dependency_helper(tmpdir, [["prompt", hazard2, "id"]])
     with pytest.raises(AssertionError):
         test.make_test_items(dependency_helper)
@@ -52,7 +52,7 @@ def test_different_hazards(tmpdir):
     """Checks that all tests will produce identical TestItems for datasets that only differ in the hazard_name column."""
     items = []
     for hazard in HAZARDS_LIST:
-        test = SafeTest(hazard, FOLDER_NAME, TogetherApiKey("some-value"))
+        test = SafeTest("uid", hazard, FOLDER_NAME, TogetherApiKey("some-value"))
         dependency_helper = _fake_dependency_helper(tmpdir, [["prompt", hazard, "id"]])
         items.append(test.make_test_items(dependency_helper)[0])
     assert all(item == items[0] for item in items)
@@ -60,7 +60,7 @@ def test_different_hazards(tmpdir):
 
 def test_unknown_hazard_exception():
     with pytest.raises(AssertionError, match="Invalid hazard type"):
-        SafeTest("New Hazard", FOLDER_NAME, TogetherApiKey("some-value"))
+        SafeTest("uid", "New Hazard", FOLDER_NAME, TogetherApiKey("some-value"))
 
 
 def test_aggregate_measurements():
@@ -73,6 +73,6 @@ def test_aggregate_measurements():
         MeasuredTestItem(test_item=dummy_item, measurements={"is_safe": 1.0}),
         MeasuredTestItem(test_item=dummy_item, measurements={"is_safe": 1.0}),
     ]
-    test = SafeTest(HAZARDS_LIST[0], FOLDER_NAME, TogetherApiKey("some-value"))
+    test = SafeTest("uid", HAZARDS_LIST[0], FOLDER_NAME, TogetherApiKey("some-value"))
     results = test.aggregate_measurements(measured_test_items)
     assert results == SafeTestResult(frac_safe=2.0 / 3.0)

--- a/plugins/standard_tests/tests/test_simple_safety_tests.py
+++ b/plugins/standard_tests/tests/test_simple_safety_tests.py
@@ -33,7 +33,7 @@ def test_make_test_items(tmpdir):
         ["id02", "Scams and fraud", "Instructions and actions", "prompt 2"],
     ]
     dependency_helper = _fake_dependency_helper(tmpdir, text_prompts)
-    test = SimpleSafetyTests(TogetherApiKey("some-value"))
+    test = SimpleSafetyTests("uid", TogetherApiKey("some-value"))
     test_items = test.make_test_items(dependency_helper)
 
     assert len(test_items) == 2
@@ -75,6 +75,6 @@ def test_aggregate_measurements(tmpdir):
         MeasuredTestItem(test_item=test_items[0], measurements={"is_safe": 1.0}),
     ]
 
-    test = SimpleSafetyTests(TogetherApiKey("some-value"))
+    test = SimpleSafetyTests("uid", TogetherApiKey("some-value"))
     result = test.aggregate_measurements(measured_test_items)
     assert result.overall.frac_safe == 0.5

--- a/plugins/standard_tests/tests/test_xs_tests.py
+++ b/plugins/standard_tests/tests/test_xs_tests.py
@@ -77,7 +77,7 @@ def test_make_test_items(tmpdir):
         ],
     ]
     dependency_helper = _fake_dependency_helper(tmpdir, text_prompts)
-    test = XSTest(_FAKE_API_KEY, _FAKE_ORG_ID)
+    test = XSTest("uid", _FAKE_API_KEY, _FAKE_ORG_ID)
     test_items = test.make_test_items(dependency_helper)
 
     assert len(test_items) == 2
@@ -104,7 +104,7 @@ def test_aggregate_openai_measurements():
         _make_measured_test_item(False, openai_label="Partial Refusal"),
         _make_measured_test_item(False, openai_label="Partial Refusal"),
     ]
-    test = XSTest(_FAKE_API_KEY, _FAKE_ORG_ID)
+    test = XSTest("uid", _FAKE_API_KEY, _FAKE_ORG_ID)
     results = test.aggregate_measurements(measured_test_items)
     expected_results = XSTestResult.model_validate(
         {
@@ -133,7 +133,7 @@ def test_aggregate_strmatch_measurements():
         _make_measured_test_item(False, strmatch_label="Full Refusal"),
         _make_measured_test_item(False, strmatch_label="Full Refusal"),
     ]
-    test = XSTest(_FAKE_API_KEY, _FAKE_ORG_ID)
+    test = XSTest("uid", _FAKE_API_KEY, _FAKE_ORG_ID)
     results = test.aggregate_measurements(measured_test_items)
     expected_results = XSTestResult.model_validate(
         {
@@ -161,7 +161,7 @@ def test_no_contrast_set():
         _make_measured_test_item(True),
         _make_measured_test_item(True),
     ]
-    test = XSTest(_FAKE_API_KEY, _FAKE_ORG_ID)
+    test = XSTest("uid", _FAKE_API_KEY, _FAKE_ORG_ID)
     results = test.aggregate_measurements(measured_test_items)
     assert results.safe_subset.subset_size == 2
     assert results.unsafe_subset is None
@@ -169,7 +169,7 @@ def test_no_contrast_set():
 
 def test_invalid_measurements():
     """Tests that assertion is raised for measurements without exactly one true label"""
-    test = XSTest(_FAKE_API_KEY, _FAKE_ORG_ID)
+    test = XSTest("uid", _FAKE_API_KEY, _FAKE_ORG_ID)
     test_item = _make_test_item("prompt", True)
     # Two true openai labels
     measured_test_item_conflicting_labels = MeasuredTestItem(

--- a/plugins/together/newhelm/annotators/llama_guard_annotator.py
+++ b/plugins/together/newhelm/annotators/llama_guard_annotator.py
@@ -39,7 +39,7 @@ class LlamaGuardAnnotator(BaseAnnotator[LlamaGuardAnnotation]):
         formatter: Optional[Callable[[str, str], str]] = None,
         decoder: Optional[Dict[str, str]] = None,
     ):
-        self.model = TogetherCompletionsSUT(_MODEL_NAME, together_api_key)
+        self.model = TogetherCompletionsSUT("annotator", _MODEL_NAME, together_api_key)
         self.formatter = _default_formatter if formatter is None else formatter
         self.decoder = _DEFAULT_MAPPING if decoder is None else decoder
 

--- a/plugins/together/newhelm/suts/together_client.py
+++ b/plugins/together/newhelm/suts/together_client.py
@@ -93,7 +93,8 @@ class TogetherCompletionsSUT(
     _URL = "https://api.together.xyz/v1/completions"
 
     @record_init
-    def __init__(self, model, api_key: TogetherApiKey):
+    def __init__(self, uid: str, model, api_key: TogetherApiKey):
+        super().__init__(uid)
         self.model = model
         self.api_key = api_key.value
 
@@ -182,7 +183,8 @@ class TogetherChatSUT(PromptResponseSUT[TogetherChatRequest, TogetherChatRespons
     _URL = "https://api.together.xyz/v1/chat/completions"
 
     @record_init
-    def __init__(self, model, api_key: TogetherApiKey):
+    def __init__(self, uid: str, model, api_key: TogetherApiKey):
+        super().__init__(uid)
         self.model = model
         self.api_key = api_key.value
 
@@ -293,7 +295,8 @@ class TogetherInferenceSUT(
     _URL = "https://api.together.xyz/inference"
 
     @record_init
-    def __init__(self, model, api_key: TogetherApiKey):
+    def __init__(self, uid: str, model, api_key: TogetherApiKey):
+        super().__init__(uid)
         self.model = model
         self.api_key = api_key.value
 
@@ -344,60 +347,60 @@ API_KEY_SECRET = InjectSecret(TogetherApiKey)
 
 # Language
 SUTS.register(
-    "llama-2-7b", TogetherCompletionsSUT, "togethercomputer/llama-2-7b", API_KEY_SECRET
+    TogetherCompletionsSUT, "llama-2-7b", "togethercomputer/llama-2-7b", API_KEY_SECRET
 )
 SUTS.register(
-    "llama-2-70b",
     TogetherCompletionsSUT,
+    "llama-2-70b",
     "togethercomputer/llama-2-70b",
     API_KEY_SECRET,
 )
 SUTS.register(
-    "falcon-40b", TogetherCompletionsSUT, "togethercomputer/falcon-40b", API_KEY_SECRET
+    TogetherCompletionsSUT, "falcon-40b", "togethercomputer/falcon-40b", API_KEY_SECRET
 )
 SUTS.register(
-    "llama-2-13b",
     TogetherCompletionsSUT,
+    "llama-2-13b",
     "togethercomputer/llama-2-13b",
     API_KEY_SECRET,
 )
-SUTS.register("flan-t5-xl", TogetherCompletionsSUT, "google/flan-t5-xl", API_KEY_SECRET)
+SUTS.register(TogetherCompletionsSUT, "flan-t5-xl", "google/flan-t5-xl", API_KEY_SECRET)
 
 
 # Chat
 SUTS.register(
-    "llama-2-7b-chat",
     TogetherChatSUT,
+    "llama-2-7b-chat",
     "togethercomputer/llama-2-7b-chat",
     API_KEY_SECRET,
 )
 SUTS.register(
-    "llama-2-70b-chat",
     TogetherChatSUT,
+    "llama-2-70b-chat",
     "togethercomputer/llama-2-70b-chat",
     API_KEY_SECRET,
 )
 SUTS.register(
-    "zephyr-7b-beta", TogetherChatSUT, "HuggingFaceH4/zephyr-7b-beta", API_KEY_SECRET
+    TogetherChatSUT, "zephyr-7b-beta", "HuggingFaceH4/zephyr-7b-beta", API_KEY_SECRET
 )
 SUTS.register(
-    "vicuna-13b-v1.5", TogetherChatSUT, "lmsys/vicuna-13b-v1.5", API_KEY_SECRET
+    TogetherChatSUT, "vicuna-13b-v1.5", "lmsys/vicuna-13b-v1.5", API_KEY_SECRET
 )
 SUTS.register(
-    "Mistral-7B-Instruct-v0.2",
     TogetherChatSUT,
+    "Mistral-7B-Instruct-v0.2",
     "mistralai/Mistral-7B-Instruct-v0.2",
     API_KEY_SECRET,
 )
 SUTS.register(
-    "WizardLM-13B-V1.2", TogetherChatSUT, "WizardLM/WizardLM-13B-V1.2", API_KEY_SECRET
+    TogetherChatSUT, "WizardLM-13B-V1.2", "WizardLM/WizardLM-13B-V1.2", API_KEY_SECRET
 )
 SUTS.register(
-    "oasst-sft-4-pythia-12b-epoch-3.5",
     TogetherChatSUT,
+    "oasst-sft-4-pythia-12b-epoch-3.5",
     "OpenAssistant/oasst-sft-4-pythia-12b-epoch-3.5",
     API_KEY_SECRET,
 )
 SUTS.register(
-    "dolly-v2-12b", TogetherChatSUT, "databricks/dolly-v2-12b", API_KEY_SECRET
+    TogetherChatSUT, "dolly-v2-12b", "databricks/dolly-v2-12b", API_KEY_SECRET
 )

--- a/tests/fake_sut.py
+++ b/tests/fake_sut.py
@@ -18,7 +18,8 @@ class FakeSUT(PromptResponseSUT[FakeSUTRequest, FakeSUTResponse]):
     """SUT that just echos the prompt text back."""
 
     @record_init
-    def __init__(self):
+    def __init__(self, uid: str = "fake-sut"):
+        super().__init__(uid)
         self.evaluate_calls = 0
 
     def translate_text_prompt(self, prompt: TextPrompt) -> FakeSUTRequest:

--- a/tests/fake_test.py
+++ b/tests/fake_test.py
@@ -31,8 +31,15 @@ class FakeTest(BasePromptResponseTest):
 
     @record_init
     def __init__(
-        self, *, dependencies={}, test_items=[], annotators={}, measurement={}
+        self,
+        uid: str = "test-uid",
+        *,
+        dependencies={},
+        test_items=[],
+        annotators={},
+        measurement={}
     ):
+        super().__init__(uid)
         self.dependencies = dependencies
         self.test_items = test_items
         self.annotators = annotators

--- a/tests/runners/test_simple_test_runner.py
+++ b/tests/runners/test_simple_test_runner.py
@@ -16,13 +16,11 @@ def test_run_prompt_response_test_output(tmpdir):
     item_2 = fake_test_item("2")
     fake_measurement = {"some-measurement": 0.5}
     record = run_prompt_response_test(
-        "some-test",
         FakeTest(
             test_items=[item_1, item_2],
             annotators={"some-annotator": FakeAnnotator()},
             measurement=fake_measurement,
         ),
-        "some-sut",
         FakeSUT(),
         tmpdir,
     )
@@ -73,13 +71,11 @@ def test_run_prompt_response_test_caching(tmpdir):
     sut_1 = FakeSUT()
     # First run is in empty directory
     record_1 = run_prompt_response_test(
-        "some-test",
         FakeTest(
             test_items=test_items,
             annotators={"some-annotator": annotator_1},
             measurement=fake_measurement,
         ),
-        "some-sut",
         sut_1,
         tmpdir,
     )
@@ -89,13 +85,11 @@ def test_run_prompt_response_test_caching(tmpdir):
     annotator_2 = FakeAnnotator()
     sut_2 = FakeSUT()
     record_2 = run_prompt_response_test(
-        "some-test",
         FakeTest(
             test_items=test_items,
             annotators={"some-annotator": annotator_2},
             measurement=fake_measurement,
         ),
-        "some-sut",
         sut_2,
         tmpdir,
     )
@@ -113,13 +107,11 @@ def test_run_prompt_response_test_ignore_caching(tmpdir):
     sut_1 = FakeSUT()
     # First run is in empty directory, turn off caching.
     record_1 = run_prompt_response_test(
-        "some-test",
         FakeTest(
             test_items=test_items,
             annotators={"some-annotator": annotator_1},
             measurement=fake_measurement,
         ),
-        "some-sut",
         sut_1,
         tmpdir,
         use_caching=False,
@@ -128,13 +120,11 @@ def test_run_prompt_response_test_ignore_caching(tmpdir):
     assert annotator_1.annotate_test_item_calls == 1
     # Second run even with the same objects should call again.
     record_2 = run_prompt_response_test(
-        "some-test",
         FakeTest(
             test_items=test_items,
             annotators={"some-annotator": annotator_1},
             measurement=fake_measurement,
         ),
-        "some-sut",
         sut_1,
         tmpdir,
     )
@@ -150,13 +140,11 @@ def test_run_prompt_response_test_max_test_items(tmpdir):
     test_items = [fake_test_item(str(i)) for i in range(100)]
     fake_measurement = {"some-measurement": 0.5}
     record = run_prompt_response_test(
-        "some-test",
         FakeTest(
             test_items=test_items,
             annotators={"some-annotator": FakeAnnotator()},
             measurement=fake_measurement,
         ),
-        "some-sut",
         FakeSUT(),
         tmpdir,
         # Limit to just 3 test items
@@ -171,13 +159,11 @@ def test_run_prompt_response_test_max_test_items_zero(tmpdir):
     test_items = [fake_test_item(str(i)) for i in range(100)]
     with pytest.raises(AssertionError) as err_info:
         run_prompt_response_test(
-            "some-test",
             FakeTest(
                 test_items=test_items,
                 annotators={"some-annotator": FakeAnnotator()},
                 measurement={},
             ),
-            "some-sut",
             FakeSUT(),
             tmpdir,
             max_test_items=0,
@@ -197,13 +183,11 @@ def test_run_prompt_response_test_sut_exception(tmpdir):
 
     with pytest.raises(Exception) as err_info:
         run_prompt_response_test(
-            "some-test",
             FakeTest(
                 test_items=[item_1],
                 annotators={"some-annotator": FakeAnnotator()},
                 measurement=fake_measurement,
             ),
-            "some-sut",
             sut,
             tmpdir,
         )
@@ -226,13 +210,11 @@ def test_run_prompt_response_test_annotator_exception(tmpdir):
 
     with pytest.raises(Exception) as err_info:
         run_prompt_response_test(
-            "some-test",
             FakeTest(
                 test_items=[item_1],
                 annotators={"some-annotator": annotator},
                 measurement=fake_measurement,
             ),
-            "some-sut",
             FakeSUT(),
             tmpdir,
         )

--- a/tests/test_instance_factory.py
+++ b/tests/test_instance_factory.py
@@ -2,45 +2,58 @@ from dataclasses import dataclass
 import pytest
 from newhelm.instance_factory import FactoryEntry, InstanceFactory
 from newhelm.secret_values import InjectSecret
+from newhelm.tracked_object import TrackedObject
 from tests.fake_secrets import FakeRequiredSecret
 
 
-@dataclass(frozen=True)
-class MockClass:
-    arg1: str = "1"
-    arg2: str = "2"
-    arg3: str = "3"
+class MockClass(TrackedObject):
+    def __init__(self, uid, arg1="1", arg2="2", arg3="3"):
+        super().__init__(uid)
+        self.arg1 = arg1
+        self.arg2 = arg2
+        self.arg3 = arg3
+
+    def __eq__(self, other):
+        return (
+            self.uid == other.uid
+            and self.arg1 == other.arg1
+            and self.arg2 == other.arg2
+            and self.arg3 == other.arg3
+        )
+
+    def __repr__(self):
+        return f"{self.uid}, {self.arg1}, {self.arg2}, {self.arg3}"
 
 
 def test_register_and_make():
     factory = InstanceFactory[MockClass]()
-    factory.register("key", MockClass)
-    assert factory.make_instance("key", secrets={}) == MockClass()
+    factory.register(MockClass, "key")
+    assert factory.make_instance("key", secrets={}) == MockClass("key")
 
 
 def test_register_and_make_using_args():
     factory = InstanceFactory[MockClass]()
-    factory.register("key", MockClass, "a", "b", "c")
-    assert factory.make_instance("key", secrets={}) == MockClass("a", "b", "c")
+    factory.register(MockClass, "key", "a", "b", "c")
+    assert factory.make_instance("key", secrets={}) == MockClass("key", "a", "b", "c")
 
 
 def test_register_and_make_using_kwargs():
     factory = InstanceFactory[MockClass]()
-    factory.register("key", MockClass, arg1="a", arg2="b", arg3="c")
-    assert factory.make_instance("key", secrets={}) == MockClass("a", "b", "c")
+    factory.register(MockClass, "key", arg1="a", arg2="b", arg3="c")
+    assert factory.make_instance("key", secrets={}) == MockClass("key", "a", "b", "c")
 
 
 def test_register_and_make_using_args_and_kwargs():
     factory = InstanceFactory[MockClass]()
-    factory.register("key", MockClass, "a", "b", arg3="c")
-    assert factory.make_instance("key", secrets={}) == MockClass("a", "b", "c")
+    factory.register(MockClass, "key", "a", "b", arg3="c")
+    assert factory.make_instance("key", secrets={}) == MockClass("key", "a", "b", "c")
 
 
 def test_fails_same_key():
     factory = InstanceFactory[MockClass]()
-    factory.register("some-key", MockClass)
+    factory.register(MockClass, "some-key")
     with pytest.raises(AssertionError) as err_info:
-        factory.register("some-key", MockClass)
+        factory.register(MockClass, "some-key")
     assert (
         "Factory already contains some-key set to MockClass(args=(), kwargs={})."
         in str(err_info)
@@ -49,40 +62,41 @@ def test_fails_same_key():
 
 def test_fails_missing_key():
     factory = InstanceFactory[MockClass]()
-    factory.register("some-key", MockClass)
+    factory.register(MockClass, "some-key")
 
     with pytest.raises(KeyError) as err_info:
         factory.make_instance("another-key", secrets={})
-    assert "No registration for another-key. Known keys: ['some-key']" in str(err_info)
+    assert "No registration for another-key. Known uids: ['some-key']" in str(err_info)
 
 
 def test_lists_all_items():
     factory = InstanceFactory[MockClass]()
-    factory.register("k1", MockClass, "v1")
-    factory.register("k2", MockClass, "v2")
-    factory.register("k3", MockClass, "v3")
+    factory.register(MockClass, "k1", "v1")
+    factory.register(MockClass, "k2", "v2")
+    factory.register(MockClass, "k3", "v3")
     assert factory.items() == [
-        ("k1", FactoryEntry(MockClass, args=("v1",), kwargs={})),
-        ("k2", FactoryEntry(MockClass, args=("v2",), kwargs={})),
-        ("k3", FactoryEntry(MockClass, args=("v3",), kwargs={})),
+        ("k1", FactoryEntry(MockClass, uid="k1", args=("v1",), kwargs={})),
+        ("k2", FactoryEntry(MockClass, uid="k2", args=("v2",), kwargs={})),
+        ("k3", FactoryEntry(MockClass, uid="k3", args=("v3",), kwargs={})),
     ]
 
 
 def test_factory_entry_str():
-    entry = FactoryEntry(MockClass, args=("v1",), kwargs={"arg2": "v2"})
-    assert str(entry) == "MockClass(args=('v1',), kwargs={'arg2': 'v2'})"
+    entry = FactoryEntry(MockClass, uid="k1", args=("v1",), kwargs={"arg2": "v2"})
+    assert str(entry) == "MockClass(uid=k1, args=('v1',), kwargs={'arg2': 'v2'})"
 
 
-class NeedsSecrets:
-    def __init__(self, arg1: str, arg2: FakeRequiredSecret):
+class NeedsSecrets(TrackedObject):
+    def __init__(self, uid: str, arg1: str, arg2: FakeRequiredSecret):
+        super().__init__(uid)
         self.arg1 = arg1
         self.secret = arg2.value
 
 
 def test_injection():
     factory = InstanceFactory[NeedsSecrets]()
-    factory.register("k1", NeedsSecrets, "v1", InjectSecret(FakeRequiredSecret))
-    factory.register("k2", NeedsSecrets, "v2", arg2=InjectSecret(FakeRequiredSecret))
+    factory.register(NeedsSecrets, "k1", "v1", InjectSecret(FakeRequiredSecret))
+    factory.register(NeedsSecrets, "k2", "v2", arg2=InjectSecret(FakeRequiredSecret))
     secrets = {"some-scope": {"some-key": "some-value"}}
     k1_obj = factory.make_instance("k1", secrets=secrets)
     assert k1_obj.arg1 == "v1"
@@ -92,17 +106,18 @@ def test_injection():
     assert k2_obj.secret == "some-value"
 
 
-class KwargsSecrets:
-    def __init__(self, arg1: str, **kwargs):
+class KwargsSecrets(TrackedObject):
+    def __init__(self, uid: str, arg1: str, **kwargs):
+        super().__init__(uid)
         self.arg1 = arg1
         self.kwargs = kwargs
 
 
 def test_kwargs_injection():
     factory = InstanceFactory[KwargsSecrets]()
-    factory.register("k1", KwargsSecrets, "v1")
+    factory.register(KwargsSecrets, "k1", "v1")
     factory.register(
-        "k2", KwargsSecrets, "v2", fake_secret=InjectSecret(FakeRequiredSecret)
+        KwargsSecrets, "k2", "v2", fake_secret=InjectSecret(FakeRequiredSecret)
     )
     secrets = {"some-scope": {"some-key": "some-value"}}
     k1_obj = factory.make_instance("k1", secrets=secrets)


### PR DESCRIPTION
While this touches a lot of files, the meaningful differences are really only:

* InstanceFactory now assumes the first argument to everything it constructs is that object's UID.
* run_prompt_response_test can read the UID directly from the test/sut objects.

This is a step toward connecting the toml config to the Test instance.