### PR TITLE
Define InitHooksMetaclass to replace record_init

### DIFF
--- a/demo_plugin/newhelm/suts/demo_02_secrets_and_options_sut.py
+++ b/demo_plugin/newhelm/suts/demo_02_secrets_and_options_sut.py
@@ -2,7 +2,6 @@ import random
 from typing import Optional, Sequence
 from pydantic import BaseModel
 from newhelm.prompt import ChatPrompt, SUTOptions, TextPrompt
-from newhelm.record_init import record_init
 from newhelm.secret_values import InjectSecret, RequiredSecret, SecretDescription
 from newhelm.sut import SUTCompletion, SUTResponse, PromptResponseSUT
 from newhelm.sut_registry import SUTS
@@ -37,13 +36,8 @@ class DemoRandomWords(
 ):
     """SUT that returns random words based on the input prompt."""
 
-    @record_init
     def __init__(self, api_key: DemoApiKey):
-        """Secrets should be passed into the constructor.
-
-        The @record_init decorator is used to make sure the framework can
-        reconstruct your SUT later if someone wants to reproduce existing results.
-        """
+        """Secrets should be passed into the constructor."""
         self.api_key = api_key.value
         # Use lazy initialization of the client so we don't have to do a lot of work
         # until its actually needed.

--- a/demo_plugin/newhelm/suts/demo_03_sut_with_args.py
+++ b/demo_plugin/newhelm/suts/demo_03_sut_with_args.py
@@ -1,6 +1,5 @@
 from pydantic import BaseModel
 from newhelm.prompt import ChatPrompt, TextPrompt
-from newhelm.record_init import record_init
 from newhelm.sut import SUTCompletion, SUTResponse, PromptResponseSUT
 from newhelm.sut_registry import SUTS
 
@@ -20,7 +19,6 @@ class DemoConstantResponse(BaseModel):
 class DemoConstantSUT(PromptResponseSUT[DemoConstantRequest, DemoConstantResponse]):
     """This SUT allows you to configure the response it will always give."""
 
-    @record_init
     def __init__(self, response_text: str):
         self.response_text = response_text
 

--- a/demo_plugin/newhelm/tests/demo_04_using_annotation_test.py
+++ b/demo_plugin/newhelm/tests/demo_04_using_annotation_test.py
@@ -8,7 +8,6 @@ from newhelm.base_test import BasePromptResponseTest, TestMetadata
 from newhelm.dependency_helper import DependencyHelper
 from newhelm.external_data import ExternalData
 from newhelm.prompt import TextPrompt
-from newhelm.record_init import record_init
 from newhelm.single_turn_prompt_response import (
     TestItemAnnotations,
     MeasuredTestItem,
@@ -29,7 +28,6 @@ class DemoUsingAnnotationTest(BasePromptResponseTest):
         # This Test generates strings in memory and has no dependencies.
         return {}
 
-    @record_init
     def __init__(self, num_samples=10, seed=0):
         self.num_samples = num_samples
         self.seed = seed

--- a/docs/tutorial_suts.md
+++ b/docs/tutorial_suts.md
@@ -121,12 +121,9 @@ This code is giving a name to our new secret (`demo.api_key`) and providing inst
 Secrets should be passed into a SUT's `__init__` function:
 
 ```py
-@record_init
 def __init__(self, api_key: DemoApiKey):
     self.api_key = api_key.value
 ```
-
-Because we are defining a custom `__init__`, the `@record_init` decorator is needed to ensure someone can reconstruct your SUT using the same arguments as previous run. This recording will automatically strip out the secret value, and leave only the `DemoApiKey` class itself.
 
 The `.value` property on `RequiredSecret` returns the `str` secret itself, so we can pass that to our API: `RandomWordsClient(api_key=self.api_key)`.
 
@@ -177,7 +174,6 @@ Many APIs allow you to interact with different models as easily as switching a r
 
 ```py
 class DemoConstantSUT(PromptResponseSUT[DemoConstantRequest, DemoConstantResponse]):
-    @record_init
     def __init__(self, response_text: str):
         self.response_text = response_text
 ```

--- a/newhelm/base_test.py
+++ b/newhelm/base_test.py
@@ -5,8 +5,9 @@ from pydantic import BaseModel
 from newhelm.base_annotator import BaseAnnotator
 from newhelm.dependency_helper import DependencyHelper
 from newhelm.external_data import ExternalData
+from newhelm.init_hooks import ABCInitHooksMetaclass
 
-from newhelm.record_init import record_init
+from newhelm.record_init import add_initialization_record
 from newhelm.single_turn_prompt_response import (
     TestItemAnnotations,
     MeasuredTestItem,
@@ -26,7 +27,7 @@ class TestMetadata(BaseModel):
     __test__ = False
 
 
-class BaseTest(ABC):
+class BaseTest(ABC, metaclass=ABCInitHooksMetaclass):
     """This is the placeholder base class for all tests."""
 
     @abstractmethod
@@ -34,15 +35,8 @@ class BaseTest(ABC):
         """Return a description of the test."""
         pass
 
-    @record_init
-    def __init__(self):
-        """Ensure all Tests default to recording their initialization.
-
-        We want to ensure all Tests record their init to allow us to reconstruct
-        their behavior later. If a Test needs to define its own __init__ that is fine,
-        it should just include the decorator.
-        """
-        pass
+    def _before_init(self, *args, **kwargs):
+        add_initialization_record(self, *args, **kwargs)
 
 
 class BasePromptResponseTest(BaseTest, ABC):

--- a/newhelm/init_hooks.py
+++ b/newhelm/init_hooks.py
@@ -1,3 +1,4 @@
+import abc
 from functools import wraps
 
 
@@ -8,6 +9,12 @@ class InitHooksMetaclass(type):
         result = super().__new__(cls, *args, **kwargs)
         result.__init__ = _wrap_init(result.__init__)
         return result
+
+
+class ABCInitHooksMetaclass(InitHooksMetaclass, abc.ABCMeta):
+    """Combine InitHooksMetaclass and ABC."""
+
+    pass
 
 
 def _wrap_init(init):
@@ -23,7 +30,7 @@ def _wrap_init(init):
             self._init_nesting = 1
         # Call the underlying __init__ function
         init(self, *args, **kwargs)
-        
+
         self._init_nesting -= 1
         if self._init_nesting == 0:
             if hasattr(self, "_after_init"):

--- a/newhelm/init_hooks.py
+++ b/newhelm/init_hooks.py
@@ -1,0 +1,33 @@
+from functools import wraps
+
+
+class InitHooksMetaclass(type):
+    """Metaclass that will call _before_init and _after_init functions if present."""
+
+    def __new__(cls, *args, **kwargs):
+        result = super().__new__(cls, *args, **kwargs)
+        result.__init__ = _wrap_init(result.__init__)
+        return result
+
+
+def _wrap_init(init):
+    @wraps(init)
+    def inner(self, *args, **kwargs):
+        try:
+            # Keep track of how many `init` calls we've
+            # done to ensure before and after only happen once.
+            self._init_nesting += 1
+        except AttributeError:
+            if hasattr(self, "_before_init"):
+                self._before_init(*args, **kwargs)
+            self._init_nesting = 1
+        # Call the underlying __init__ function
+        init(self, *args, **kwargs)
+        
+        self._init_nesting -= 1
+        if self._init_nesting == 0:
+            if hasattr(self, "_after_init"):
+                self._after_init()
+            del self._init_nesting
+
+    return inner

--- a/newhelm/record_init.py
+++ b/newhelm/record_init.py
@@ -25,24 +25,15 @@ class InitializationRecord(BaseModel):
         return cls(*args, **kwargs)
 
 
-def record_init(init):
-    """Decorator for the __init__ function to store what arguments were passed."""
-
-    @wraps(init)
-    def wrapped_init(*args, **kwargs):
-        self, real_args = args[0], args[1:]
-        # We want the outer-most init to be recorded, so don't overwrite it.
-        record_args, record_kwargs = serialize_injected_dependencies(real_args, kwargs)
-        if not hasattr(self, "_initialization_record"):
-            self._initialization_record = InitializationRecord(
-                module=self.__class__.__module__,
-                class_name=self.__class__.__qualname__,
-                args=record_args,
-                kwargs=record_kwargs,
-            )
-        init(*args, **kwargs)
-
-    return wrapped_init
+def add_initialization_record(self, *args, **kwargs):
+    # We want the outer-most init to be recorded, so don't overwrite it.
+    record_args, record_kwargs = serialize_injected_dependencies(args, kwargs)
+    self._initialization_record = InitializationRecord(
+        module=self.__class__.__module__,
+        class_name=self.__class__.__qualname__,
+        args=record_args,
+        kwargs=record_kwargs,
+    )
 
 
 def get_initialization_record(obj) -> InitializationRecord:
@@ -52,7 +43,7 @@ def get_initialization_record(obj) -> InitializationRecord:
     except AttributeError:
         raise AssertionError(
             f"Class {obj.__class__.__qualname__} in module "
-            f"{obj.__class__.__module__} needs to add "
-            f"`@record_init` to its `__init__` function to "
-            f"enable system reproducibility."
+            f"{obj.__class__.__module__} needs to call "
+            f"`add_initialization_record` to its `__init__` "
+            f"or `_after_init` to enable system reproducibility."
         )

--- a/newhelm/sut.py
+++ b/newhelm/sut.py
@@ -2,9 +2,10 @@ from abc import ABC, abstractmethod
 from typing import Generic, List, TypeVar
 
 from pydantic import BaseModel
+from newhelm.init_hooks import ABCInitHooksMetaclass
 
 from newhelm.prompt import ChatPrompt, TextPrompt
-from newhelm.record_init import record_init
+from newhelm.record_init import add_initialization_record
 
 RequestType = TypeVar("RequestType")
 ResponseType = TypeVar("ResponseType")
@@ -22,18 +23,11 @@ class SUTResponse(BaseModel):
     completions: List[SUTCompletion]
 
 
-class SUT(ABC):
+class SUT(ABC, metaclass=ABCInitHooksMetaclass):
     """Base class for all SUTs. There is no guaranteed interface between SUTs, so no methods here."""
 
-    @record_init
-    def __init__(self):
-        """Ensure all SUTs default to recording their initialization.
-
-        We want to ensure all SUTs record their init to allow us to reconstruct
-        their behavior later. If a SUT needs to define its own __init__ that is fine,
-        it should just include the decorator.
-        """
-        pass
+    def _before_init(self, *args, **kwargs):
+        add_initialization_record(self, *args, **kwargs)
 
 
 class PromptResponseSUT(SUT, ABC, Generic[RequestType, ResponseType]):

--- a/plugins/huggingface/newhelm/suts/huggingface_client.py
+++ b/plugins/huggingface/newhelm/suts/huggingface_client.py
@@ -16,7 +16,6 @@ from newhelm.concurrency import ThreadSafeWrapper
 from newhelm.general import value_or_default
 from newhelm.prompt import ChatPrompt, TextPrompt
 from newhelm.prompt_formatting import format_chat
-from newhelm.record_init import record_init
 from newhelm.secret_values import (
     InjectSecret,
     OptionalSecret,
@@ -262,7 +261,6 @@ class HuggingFaceToken(OptionalSecret):
 class HuggingFaceSUT(PromptResponseSUT[HuggingFaceRequest, HuggingFaceResponse]):
     """A thin wrapper around a Hugging Face AutoModelForCausalLM for HuggingFaceClient to call."""
 
-    @record_init
     def __init__(
         self, pretrained_model_name_or_path: str, token: HuggingFaceToken, **kwargs
     ):

--- a/plugins/openai/newhelm/suts/openai_client.py
+++ b/plugins/openai/newhelm/suts/openai_client.py
@@ -2,7 +2,6 @@ from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel
 from newhelm.prompt import ChatPrompt, ChatRole, SUTOptions, TextPrompt
-from newhelm.record_init import record_init
 from newhelm.secret_values import (
     InjectSecret,
     OptionalSecret,
@@ -82,7 +81,6 @@ class OpenAIChat(PromptResponseSUT[OpenAIChatRequest, ChatCompletion]):
     Documented at https://platform.openai.com/docs/api-reference/chat/create
     """
 
-    @record_init
     def __init__(self, model: str, api_key: OpenAIApiKey, org_id: OpenAIOrgId):
         self.model = model
         self.client: Optional[OpenAI] = None

--- a/plugins/standard_tests/newhelm/tests/bbq.py
+++ b/plugins/standard_tests/newhelm/tests/bbq.py
@@ -16,7 +16,6 @@ from newhelm.multiple_choice_questions import (
 )
 from newhelm.external_data import ExternalData, WebData
 from newhelm.prompt import TextPrompt, SUTOptions
-from newhelm.record_init import record_init
 from newhelm.single_turn_prompt_response import (
     TestItemAnnotations,
     MeasuredTestItem,
@@ -125,7 +124,6 @@ class BBQ(BasePromptResponseTest):
             )
         return dependencies
 
-    @record_init
     def __init__(self, subject: str = "all", num_in_context_examples=5):
         self.subject = subject
         self.num_in_context_examples = num_in_context_examples

--- a/plugins/standard_tests/newhelm/tests/real_toxicity_prompts.py
+++ b/plugins/standard_tests/newhelm/tests/real_toxicity_prompts.py
@@ -18,7 +18,6 @@ from newhelm.external_data import ExternalData, WebData
 from newhelm.data_packing import TarPacker
 from newhelm.dependency_helper import DependencyHelper
 from newhelm.prompt import TextPrompt, SUTOptions
-from newhelm.record_init import record_init
 from newhelm.secret_values import InjectSecret
 from newhelm.single_turn_prompt_response import (
     TestItemAnnotations,
@@ -50,7 +49,6 @@ class RealToxicityPrompts(BasePromptResponseTest):
     Sentences are split in half, producing a prompt and a continuation.
     """
 
-    @record_init
     def __init__(self, perspective_developer_key: PerspectiveDeveloperKey):
         self.perspective_developer_key = perspective_developer_key
 

--- a/plugins/standard_tests/newhelm/tests/safe.py
+++ b/plugins/standard_tests/newhelm/tests/safe.py
@@ -12,7 +12,6 @@ from newhelm.base_test import BasePromptResponseTest, TestMetadata
 from newhelm.dependency_helper import DependencyHelper
 from newhelm.external_data import ExternalData, GDriveData
 from newhelm.prompt import TextPrompt, SUTOptions
-from newhelm.record_init import record_init
 from newhelm.secret_values import InjectSecret
 from newhelm.single_turn_prompt_response import (
     MeasuredTestItem,
@@ -38,7 +37,6 @@ class SafeTestResult(BaseModel):
 
 
 class SafeTest(BasePromptResponseTest):
-    @record_init
     def __init__(
         self,
         hazard: str,

--- a/plugins/standard_tests/newhelm/tests/simple_safety_tests.py
+++ b/plugins/standard_tests/newhelm/tests/simple_safety_tests.py
@@ -16,7 +16,6 @@ from newhelm.base_test import BasePromptResponseTest, TestMetadata
 from newhelm.dependency_helper import DependencyHelper
 from newhelm.external_data import ExternalData, WebData
 from newhelm.prompt import TextPrompt, SUTOptions
-from newhelm.record_init import record_init
 from newhelm.secret_values import InjectSecret
 from newhelm.single_turn_prompt_response import (
     MeasuredTestItem,
@@ -63,7 +62,6 @@ class SimpleSafetyTests(BasePromptResponseTest):
     It is important to note the negative predictive power of this test -- it is assessing the unsafety of a SUT, rather than the safety. Passing this test only indicates that no critical safety risks have been found; it does not guarantee that no such risks exist.
     """
 
-    @record_init
     def __init__(self, together_api_key: TogetherApiKey):
         self.together_api_key = together_api_key
 

--- a/plugins/standard_tests/newhelm/tests/xstest.py
+++ b/plugins/standard_tests/newhelm/tests/xstest.py
@@ -13,7 +13,6 @@ from newhelm.base_test import BasePromptResponseTest, TestMetadata
 from newhelm.dependency_helper import DependencyHelper
 from newhelm.external_data import ExternalData, WebData
 from newhelm.prompt import TextPrompt, SUTOptions
-from newhelm.record_init import record_init
 from newhelm.secret_values import InjectSecret
 from newhelm.single_turn_prompt_response import (
     MeasuredTestItem,
@@ -49,7 +48,6 @@ class XSTest(BasePromptResponseTest):
     XSTest identifies exaggerated safety behaviors in generative language models. More specifically, it assess a model's propensity to refuse prompts that are safe. The test suite consists of 250 safe prompts (that should be fully complied with) and 200 unsafe prompts that should elicit refusal.
     """
 
-    @record_init
     def __init__(self, openai_api_key: OpenAIApiKey, openai_api_org_id: OpenAIOrgId):
         self.openai_api_key = openai_api_key
         self.openai_api_org_id = openai_api_org_id

--- a/plugins/together/newhelm/suts/together_client.py
+++ b/plugins/together/newhelm/suts/together_client.py
@@ -5,7 +5,6 @@ from requests.adapters import HTTPAdapter, Retry
 from together.utils import response_status_exception  # type: ignore
 from newhelm.prompt import ChatPrompt, ChatRole, SUTOptions, TextPrompt
 from newhelm.prompt_formatting import format_chat
-from newhelm.record_init import record_init
 from newhelm.secret_values import (
     InjectSecret,
     RequiredSecret,
@@ -92,7 +91,6 @@ class TogetherCompletionsSUT(
 ):
     _URL = "https://api.together.xyz/v1/completions"
 
-    @record_init
     def __init__(self, model, api_key: TogetherApiKey):
         self.model = model
         self.api_key = api_key.value
@@ -181,7 +179,6 @@ class TogetherChatResponse(BaseModel):
 class TogetherChatSUT(PromptResponseSUT[TogetherChatRequest, TogetherChatResponse]):
     _URL = "https://api.together.xyz/v1/chat/completions"
 
-    @record_init
     def __init__(self, model, api_key: TogetherApiKey):
         self.model = model
         self.api_key = api_key.value
@@ -292,7 +289,6 @@ class TogetherInferenceSUT(
 ):
     _URL = "https://api.together.xyz/inference"
 
-    @record_init
     def __init__(self, model, api_key: TogetherApiKey):
         self.model = model
         self.api_key = api_key.value

--- a/tests/fake_sut.py
+++ b/tests/fake_sut.py
@@ -1,7 +1,6 @@
 from typing import List
 from pydantic import BaseModel
 from newhelm.prompt import ChatPrompt, TextPrompt
-from newhelm.record_init import record_init
 from newhelm.sut import PromptResponseSUT, SUTCompletion, SUTResponse
 
 
@@ -17,7 +16,6 @@ class FakeSUTResponse(BaseModel):
 class FakeSUT(PromptResponseSUT[FakeSUTRequest, FakeSUTResponse]):
     """SUT that just echos the prompt text back."""
 
-    @record_init
     def __init__(self):
         self.evaluate_calls = 0
 

--- a/tests/fake_test.py
+++ b/tests/fake_test.py
@@ -6,7 +6,6 @@ from newhelm.base_test import BasePromptResponseTest, TestMetadata
 from newhelm.dependency_helper import DependencyHelper
 from newhelm.external_data import ExternalData
 from newhelm.prompt import TextPrompt
-from newhelm.record_init import record_init
 from newhelm.single_turn_prompt_response import (
     MeasuredTestItem,
     PromptWithContext,
@@ -29,7 +28,6 @@ class FakeTestResult(BaseModel):
 class FakeTest(BasePromptResponseTest):
     """Test that lets the user override almost all of the behavior."""
 
-    @record_init
     def __init__(
         self, *, dependencies={}, test_items=[], annotators={}, measurement={}
     ):

--- a/tests/test_metaclass.py
+++ b/tests/test_metaclass.py
@@ -1,0 +1,127 @@
+from unittest.mock import ANY
+import pytest
+from newhelm.init_hooks import InitHooksMetaclass
+
+
+class BaseWithHooks(metaclass=InitHooksMetaclass):
+    def __init__(self, arg1):
+        self.arg1 = arg1
+
+    def _before_init(self, *args, **kwargs):
+        pass
+
+    def _after_init(self):
+        pass
+
+
+def test_basic(mocker):
+    before_spy = mocker.spy(BaseWithHooks, "_before_init")
+    after_spy = mocker.spy(BaseWithHooks, "_after_init")
+    x = BaseWithHooks(1234)
+    assert x.arg1 == 1234
+    before_spy.assert_called_once_with(ANY, 1234)
+    after_spy.assert_called_once_with(ANY)
+
+
+class ChildNoHooks(BaseWithHooks):
+    def __init__(self, arg1, arg2):
+        super().__init__(arg1)
+        self.arg2 = arg2
+
+
+def test_child_no_hooks(mocker):
+    before_spy = mocker.spy(BaseWithHooks, "_before_init")
+    after_spy = mocker.spy(BaseWithHooks, "_after_init")
+    x = ChildNoHooks(1234, 5)
+    assert x.arg1 == 1234
+    assert x.arg2 == 5
+    before_spy.assert_called_once_with(ANY, 1234, 5)
+    after_spy.assert_called_once_with(ANY)
+
+
+class ChildOverridesHooks(BaseWithHooks):
+    def __init__(self, arg2):
+        # Note no arg1
+        self.arg2 = arg2
+
+    def _before_init(self, *args, **kwargs):
+        self.called_before = True
+
+    def _after_init(self):
+        self.called_after = True
+
+
+def test_child_overrides_hooks(mocker):
+    base_before_spy = mocker.spy(BaseWithHooks, "_before_init")
+    base_after_spy = mocker.spy(BaseWithHooks, "_after_init")
+    before_spy = mocker.spy(ChildOverridesHooks, "_before_init")
+    after_spy = mocker.spy(ChildOverridesHooks, "_after_init")
+    x = ChildOverridesHooks(1234)
+    assert x.arg2 == 1234
+    assert not hasattr(x, "arg1")
+    before_spy.assert_called_once_with(ANY, 1234)
+    after_spy.assert_called_once_with(ANY)
+    base_before_spy.assert_not_called()
+    base_after_spy.assert_not_called()
+
+
+class ChildCallsSuperHooks(BaseWithHooks):
+    def __init__(self, arg1, arg2):
+        super().__init__(arg1)
+        self.arg2 = arg2
+
+    def _before_init(self, *args, **kwargs):
+        super()._before_init(*args, **kwargs)
+        self.called_before = True
+
+    def _after_init(self):
+        super()._after_init()
+        self.called_after = True
+
+
+def test_child_calls_super_hooks(mocker):
+    base_before_spy = mocker.spy(BaseWithHooks, "_before_init")
+    base_after_spy = mocker.spy(BaseWithHooks, "_after_init")
+    before_spy = mocker.spy(ChildCallsSuperHooks, "_before_init")
+    after_spy = mocker.spy(ChildCallsSuperHooks, "_after_init")
+    x = ChildCallsSuperHooks(1234, arg2=5)
+    assert x.arg1 == 1234
+    assert x.arg2 == 5
+    assert x.called_before
+    assert x.called_after
+    before_spy.assert_called_once_with(ANY, 1234, arg2=5)
+    after_spy.assert_called_once_with(ANY)
+    base_before_spy.assert_called_once_with(ANY, 1234, arg2=5)
+    base_after_spy.assert_called_once_with(ANY)
+
+
+class ChildDoesProcessing(BaseWithHooks):
+    def __init__(self, arg1, arg2, arg3):
+        super().__init__(arg1)
+        self.arg2 = arg2
+        self.arg3 = arg3
+
+    def _before_init(self, arg1, arg2, arg3):
+        assert arg1 < arg2, "Before failure"
+
+    def _after_init(self):
+        assert self.arg2 < self.arg3, "After failure"
+
+
+def test_child_does_processing_before():
+    with pytest.raises(AssertionError) as err_info:
+        ChildDoesProcessing(123, 2, 3)
+    assert "Before failure" in str(err_info.value)
+
+
+def test_child_does_processing_after():
+    with pytest.raises(AssertionError) as err_info:
+        ChildDoesProcessing(1, 222, 3)
+    assert "After failure" in str(err_info.value)
+
+
+def test_child_does_processing_constructs():
+    x = ChildDoesProcessing(1, arg2=2, arg3=3)
+    assert x.arg1 == 1
+    assert x.arg2 == 2
+    assert x.arg3 == 3


### PR DESCRIPTION
Now instead of requiring every class that overrides `__init__` to specify `@record_init`, they all perform this behavior by default. This also opens the door to other kinds of validation and tracking.