### PR TITLE
Ability to register Tests via toml files.

### DIFF
--- a/demo_plugin/newhelm/tests/demo_04_using_annotation_test.py
+++ b/demo_plugin/newhelm/tests/demo_04_using_annotation_test.py
@@ -15,7 +15,6 @@ from newhelm.single_turn_prompt_response import (
     TestItem,
 )
 from newhelm.test_decorator import newhelm_test
-from newhelm.test_registry import TESTS
 
 
 @newhelm_test()
@@ -75,4 +74,4 @@ class DemoUsingAnnotationTest(BasePromptResponseTest):
         return {"bad_rate": mean_of_measurement("is_bad", items)}
 
 
-TESTS.register(DemoUsingAnnotationTest, "demo_04")
+# Registration happens via the toml file.

--- a/demo_plugin/newhelm/tests/specifications/demo_01.toml
+++ b/demo_plugin/newhelm/tests/specifications/demo_01.toml
@@ -1,4 +1,0 @@
-[identity]
-uid = "demo_01"
-version = "1"
-display_name = "Demo Simple Q&A Test"

--- a/demo_plugin/newhelm/tests/specifications/demo_04.toml
+++ b/demo_plugin/newhelm/tests/specifications/demo_04.toml
@@ -1,0 +1,7 @@
+[identity]
+uid = "demo_04"
+version = "1"
+display_name = "Demo Using Annotations"
+
+[definition]
+class_name="DemoUsingAnnotationTest"

--- a/newhelm/main.py
+++ b/newhelm/main.py
@@ -19,10 +19,14 @@ from newhelm.secret_values import MissingSecretValues, get_all_secrets
 from newhelm.sut import PromptResponseSUT
 from newhelm.sut_registry import SUTS
 from newhelm.test_registry import TESTS
+from newhelm.test_specifications import (
+    load_test_specification_files,
+    register_test_from_specifications,
+)
 
 
-@newhelm_cli.command()
-def list() -> None:
+@newhelm_cli.command(name="list")
+def list_command() -> None:
     """Overview of Plugins, Tests, and SUTs."""
     plugins = list_plugins()
     display_header(f"Plugin Modules: {len(plugins)}")
@@ -117,4 +121,6 @@ def run_sut(
 
 if __name__ == "__main__":
     load_plugins()
+    specs = load_test_specification_files()
+    register_test_from_specifications(list(specs.values()), TESTS)
     newhelm_cli()

--- a/newhelm/secret_values.py
+++ b/newhelm/secret_values.py
@@ -44,6 +44,7 @@ def get_all_secrets() -> Sequence[SecretDescription]:
 
 
 def get_secrets_lookup() -> Mapping[str, Type[BaseSecret]]:
+    """Return the Secrets classes, keyed by their name."""
     secrets = get_concrete_subclasses(BaseSecret)  # type: ignore
     return {s.__name__: s for s in secrets}
 

--- a/newhelm/secret_values.py
+++ b/newhelm/secret_values.py
@@ -43,6 +43,11 @@ def get_all_secrets() -> Sequence[SecretDescription]:
     return [s.description() for s in secrets]
 
 
+def get_secrets_lookup() -> Mapping[str, Type[BaseSecret]]:
+    secrets = get_concrete_subclasses(BaseSecret)  # type: ignore
+    return {s.__name__: s for s in secrets}
+
+
 class SerializedSecret(BaseModel):
     """Hold a pointer to the secret class in a serializable form."""
 

--- a/newhelm/test_decorator.py
+++ b/newhelm/test_decorator.py
@@ -1,18 +1,29 @@
 from functools import wraps
 import inspect
+from typing import Dict, Type
 from newhelm.base_test import BaseTest
 from newhelm.record_init import add_initialization_record
+
+NEWHELM_TESTS: Dict[str, Type[BaseTest]] = {}
 
 
 def newhelm_test():
     """Decorator providing common behavior and hooks for all NewHELM Tests."""
 
     def inner(cls):
+        if cls.__name__ in NEWHELM_TESTS:
+            previous = NEWHELM_TESTS[cls.__name__]
+            raise AssertionError(
+                f"Found two different Tests for {cls.__name__}: {cls} and {previous}."
+            )
         assert issubclass(
             cls, BaseTest
         ), "Decorator can only be applied to classes that inherit from BaseTest."
         cls.__init__ = _wrap_init(cls.__init__)
         cls._newhelm_test = True
+        assert cls.__name__ not in NEWHELM_TESTS
+        # TODO: Consider allowing name aliasing via a parameter to the decorator.
+        NEWHELM_TESTS[cls.__name__] = cls
         return cls
 
     return inner

--- a/newhelm/test_decorator.py
+++ b/newhelm/test_decorator.py
@@ -11,17 +11,17 @@ def newhelm_test():
     """Decorator providing common behavior and hooks for all NewHELM Tests."""
 
     def inner(cls):
-        if cls.__name__ in NEWHELM_TESTS:
-            previous = NEWHELM_TESTS[cls.__name__]
-            raise AssertionError(
-                f"Found two different Tests for {cls.__name__}: {cls} and {previous}."
-            )
         assert issubclass(
             cls, BaseTest
         ), "Decorator can only be applied to classes that inherit from BaseTest."
         cls.__init__ = _wrap_init(cls.__init__)
         cls._newhelm_test = True
-        assert cls.__name__ not in NEWHELM_TESTS
+
+        if cls.__name__ in NEWHELM_TESTS:
+            previous = NEWHELM_TESTS[cls.__name__]
+            raise AssertionError(
+                f"Found two different Tests for {cls.__name__}: {cls} and {previous}."
+            )
         # TODO: Consider allowing name aliasing via a parameter to the decorator.
         NEWHELM_TESTS[cls.__name__] = cls
         return cls

--- a/newhelm/test_specifications.py
+++ b/newhelm/test_specifications.py
@@ -6,7 +6,6 @@ from newhelm.base_test import BaseTest
 from newhelm.instance_factory import InstanceFactory
 from newhelm.secret_values import InjectSecret, get_secrets_lookup
 from newhelm.test_decorator import NEWHELM_TESTS
-from newhelm.test_registry import TESTS
 import newhelm.tests.specifications
 from importlib import resources
 

--- a/plugins/standard_tests/newhelm/tests/specifications/safe-cae.toml
+++ b/plugins/standard_tests/newhelm/tests/specifications/safe-cae.toml
@@ -2,3 +2,13 @@
 uid = "mls_ais_wg_safe_cae_hazardous"
 version = "data_08mar2024"
 display_name = "SafeTest: Child abuse and exploitation (Hazardous)"
+
+[definition]
+class_name = "SafeTest"
+
+[definition.keyword_arguments]
+hazard="cae"
+folder_name = "data_08mar2024"
+
+[definition.secrets]
+together_api_key="TogetherApiKey"

--- a/plugins/validation_tests/test_object_creation.py
+++ b/plugins/validation_tests/test_object_creation.py
@@ -7,12 +7,18 @@ from newhelm.load_plugins import load_plugins
 from newhelm.record_init import InitializationRecord
 from newhelm.sut_registry import SUTS
 from newhelm.test_registry import TESTS
-from newhelm.test_specifications import TestSpecification, load_test_specification_files
+from newhelm.test_specifications import (
+    TestSpecification,
+    load_test_specification_files,
+    register_test_from_specifications,
+)
 from tests.fake_secrets import fake_all_secrets
 from tests.utilities import expensive_tests
 
 # Ensure all the plugins are available during testing.
 load_plugins()
+_SPECS = load_test_specification_files()
+register_test_from_specifications(list(_SPECS.values()), TESTS)
 _FAKE_SECRETS = fake_all_secrets()
 
 
@@ -39,7 +45,7 @@ def test_plugin_test_specifications():
     _assert_some_contain(paths, "newhelm/demo_plugin/newhelm/tests/specifications")
     _assert_some_contain(paths, "newhelm/plugins/standard_tests")
     # Check for a specific specification
-    assert "demo_01" in specifications
+    assert "demo_04" in specifications
     for uid, spec in specifications.items():
         assert isinstance(
             spec, TestSpecification

--- a/tests/fake_test.py
+++ b/tests/fake_test.py
@@ -37,7 +37,7 @@ class FakeTest(BasePromptResponseTest):
         dependencies={},
         test_items=[],
         annotators={},
-        measurement={}
+        measurement={},
     ):
         super().__init__(uid)
         self.dependencies = dependencies

--- a/tests/test_secret_values.py
+++ b/tests/test_secret_values.py
@@ -8,6 +8,7 @@ from newhelm.secret_values import (
     SecretDescription,
     SerializedSecret,
     get_all_secrets,
+    get_secrets_lookup,
 )
 
 
@@ -93,6 +94,14 @@ def test_get_all_secrets():
     # This test can be impacted by other files, so just
     # check that at least one exists.
     assert len(matching) > 1, f"Found secrets: {descriptions}"
+
+
+def test_get_secrets_lookup():
+    secrets = get_secrets_lookup()
+    # We can't know what other secrets might exist, so assert
+    # these were found.
+    assert secrets["SomeRequiredSecret"] == SomeRequiredSecret
+    assert secrets["SomeOptionalSecret"] == SomeOptionalSecret
 
 
 def test_serialize_secret():

--- a/tests/test_test_decorator.py
+++ b/tests/test_test_decorator.py
@@ -87,3 +87,26 @@ def test_bad_signature():
                 self.arg1 = arg1
 
     assert "All Tests must have UID as the first parameter." in str(err_info.value)
+
+
+@newhelm_test()
+class DoubleRegister(SomeTest):
+    """In the module's scope."""
+
+    pass
+
+
+def test_double_register():
+    with pytest.raises(AssertionError) as err_info:
+        # Exception happens without even constructing an instance.
+        @newhelm_test()
+        class DoubleRegister(SomeTest):
+            """In the method's scope."""
+
+            pass
+
+    assert str(err_info.value) == (
+        "Found two different Tests for DoubleRegister: "
+        "<class 'tests.test_test_decorator.test_double_register.<locals>.DoubleRegister'> and "
+        "<class 'tests.test_test_decorator.DoubleRegister'>."
+    )

--- a/tests/test_test_specification.py
+++ b/tests/test_test_specification.py
@@ -1,10 +1,16 @@
 from typing import Any, Tuple
 
 import pytest
+from newhelm.base_test import BaseTest, TestMetadata
+from newhelm.instance_factory import InstanceFactory
+from newhelm.secret_values import RequiredSecret, SecretDescription
+from newhelm.test_decorator import newhelm_test
 from newhelm.test_specifications import (
+    Definition,
     Identity,
     TestSpecification,
     load_test_specification_files,
+    register_test_from_specifications,
 )
 
 
@@ -94,3 +100,65 @@ def test_load_repeated_uid():
 def test_load_module_no_error():
     # We don't know what files might exist, so just verify it runs.
     load_test_specification_files()
+
+
+@newhelm_test()
+class SomeRegisteredTest(BaseTest):
+    def get_metadata(self) -> TestMetadata:
+        raise NotImplementedError()
+
+
+def test_register_test_from_specifications():
+    registry = InstanceFactory[BaseTest]()
+    spec = TestSpecification(
+        source="some-source",
+        identity=Identity(uid="some-test", display_name="Some Test"),
+        definition=Definition(class_name="SomeRegisteredTest"),
+    )
+    register_test_from_specifications([spec], registry)
+    result = registry.make_instance("some-test", secrets={})
+
+    assert isinstance(result, SomeRegisteredTest)
+
+
+@newhelm_test()
+class SomeRegisteredTestWithComplexArgs(BaseTest):
+    def __init__(self, uid, arg1, the_secret, arg2):
+        self.uid = uid
+        self.arg1 = arg1
+        self.the_secret_value = the_secret.value
+        self.arg2 = arg2
+
+    def get_metadata(self) -> TestMetadata:
+        raise NotImplementedError()
+
+
+class SecretForRegistry(RequiredSecret):
+    @classmethod
+    def description(cls) -> SecretDescription:
+        return SecretDescription(
+            scope="some-scope", key="some-key", instructions="some-instructions."
+        )
+
+
+def test_register_test_from_specifications_complex_args():
+    registry = InstanceFactory[BaseTest]()
+    spec = TestSpecification(
+        source="some-source",
+        identity=Identity(uid="some-test", display_name="Some Test"),
+        definition=Definition(
+            class_name="SomeRegisteredTestWithComplexArgs",
+            keyword_arguments={"arg1": "v1", "arg2": 2},
+            secrets={"the_secret": "SecretForRegistry"},
+        ),
+    )
+    register_test_from_specifications([spec], registry)
+    result = registry.make_instance(
+        "some-test", secrets={"some-scope": {"some-key": "1234"}}
+    )
+
+    assert isinstance(result, SomeRegisteredTestWithComplexArgs)
+    assert result.uid == "some-test"
+    assert result.arg1 == "v1"
+    assert result.the_secret_value == "1234"
+    assert result.arg2 == 2


### PR DESCRIPTION
This PR provides the ability to describe all the values going into `Tests.register` from a toml file. Benefits:

* Creating a new Test now has a single touch point: the toml file.
* We can more easily link the TestSpecification with the test object.