### PR TITLE
Add new tests for 22mar2024 release

### DIFF
--- a/plugins/standard_tests/newhelm/tests/safe.py
+++ b/plugins/standard_tests/newhelm/tests/safe.py
@@ -28,9 +28,14 @@ HAZARDS_MAPPING = {
     "cae": "Child abuse and exploitation",
     "cbr": "Chemical, biological, radioloigcal, nuclear and high-yield explosives weapons",
     "gra": "Graphic depictions of hazards",
+    "hat": "Hate",
+    "nvc": "Non-violent crimes",
+    "sc": "Sexual content",
     "ssh": "Suicide, self-harm and eating disorders",
     "ter": "Terrorism",
+    "vio": "Violent crimes",
 }
+_PERSONA_TYPES = ["typical", "malicious", "vulnerable"]
 
 
 class SafeTestResult(BaseModel):
@@ -45,28 +50,29 @@ class SafeTest(BasePromptResponseTest):
         hazard: str,
         folder_name: str,
         together_api_key: TogetherApiKey,
-        benign_prompts: bool = False,
+        persona_type: str = "typical",
     ):
         super().__init__(uid)
         assert hazard in HAZARDS_MAPPING, f"Invalid hazard type {hazard}."
+        assert persona_type in _PERSONA_TYPES, f"Invalid persona type {persona_type}."
         self.hazard = hazard
         self.hazard_name = HAZARDS_MAPPING[hazard]
         self.folder_name = folder_name
         self.together_api_key = together_api_key
-        self.prompt_type = "hazardous" if not benign_prompts else "benign"
-        self.dependency_key = f"{self.folder_name}_{self.hazard}_{self.prompt_type}"
+        self.persona_type = persona_type
+        self.dependency_key = f"{self.folder_name}_{self.hazard}_{self.persona_type}"
 
     def get_metadata(self) -> TestMetadata:
         return TestMetadata(
             name=f"SafeTest",
-            description=f"Safe AI with Flexible Evaluation for {self.hazard_name} with {self.prompt_type} prompts",
+            description=f"Safe AI with Flexible Evaluation for {self.hazard_name} with {self.persona_type} prompts",
         )
 
     def get_dependencies(self) -> Mapping[str, ExternalData]:
         return {
             f"{self.dependency_key}": GDriveData(
                 data_source="https://drive.google.com/drive/folders/1FNpd9KQ1MvylgVNuWx7O0byWoFDyLBeS",
-                file_path=f"{self.folder_name}/mls_ais_wg_safe_{self.hazard}_{self.prompt_type}.csv",
+                file_path=f"{self.folder_name}/mls_ais_wg_safe_{self.hazard}_{self.persona_type}-user.csv",
             ),
         }
 
@@ -112,15 +118,75 @@ class SafeTest(BasePromptResponseTest):
         return SafeTestResult(frac_safe=mean_of_measurement("is_safe", items))
 
 
-FOLDER_NAME = "data_08mar2024"
+FOLDER_NAME = "data_22mar2024"
 API_KEY_SECRET = InjectSecret(TogetherApiKey)
-# Hazardous Prompts
 TESTS.register(
     SafeTest,
     "safe-cae",
     "cae",
     FOLDER_NAME,
     API_KEY_SECRET,
+)
+TESTS.register(
+    SafeTest,
+    "safe-cae-mal",
+    "cae",
+    FOLDER_NAME,
+    API_KEY_SECRET,
+    persona_type="malicious",
+)
+TESTS.register(
+    SafeTest,
+    "safe-cbr-mal",
+    "cbr",
+    FOLDER_NAME,
+    API_KEY_SECRET,
+    persona_type="malicious",
+)
+TESTS.register(
+    SafeTest,
+    "safe-hat",
+    "hat",
+    FOLDER_NAME,
+    API_KEY_SECRET,
+)
+TESTS.register(
+    SafeTest,
+    "safe-hat-mal",
+    "hat",
+    FOLDER_NAME,
+    API_KEY_SECRET,
+    persona_type="malicious",
+)
+TESTS.register(
+    SafeTest,
+    "safe-nvc",
+    "nvc",
+    FOLDER_NAME,
+    API_KEY_SECRET,
+)
+TESTS.register(
+    SafeTest,
+    "safe-nvc-mal",
+    "nvc",
+    FOLDER_NAME,
+    API_KEY_SECRET,
+    persona_type="malicious",
+)
+TESTS.register(
+    SafeTest,
+    "safe-sc",
+    "sc",
+    FOLDER_NAME,
+    API_KEY_SECRET,
+)
+TESTS.register(
+    SafeTest,
+    "safe-sc-mal",
+    "sc",
+    FOLDER_NAME,
+    API_KEY_SECRET,
+    persona_type="malicious",
 )
 TESTS.register(
     SafeTest,
@@ -131,6 +197,14 @@ TESTS.register(
 )
 TESTS.register(
     SafeTest,
+    "safe-ssh-vul",
+    "ssh",
+    FOLDER_NAME,
+    API_KEY_SECRET,
+    persona_type="vulnerable",
+)
+TESTS.register(
+    SafeTest,
     "safe-ter",
     "ter",
     FOLDER_NAME,
@@ -138,40 +212,17 @@ TESTS.register(
 )
 TESTS.register(
     SafeTest,
-    "safe-cbr",
-    "cbr",
-    FOLDER_NAME,
-    API_KEY_SECRET,
-)
-TESTS.register(
-    SafeTest,
-    "safe-gra",
-    "gra",
-    FOLDER_NAME,
-    API_KEY_SECRET,
-)
-# Benign prompts
-TESTS.register(
-    SafeTest,
-    "safe-cae-benign",
-    "cae",
-    FOLDER_NAME,
-    API_KEY_SECRET,
-    benign_prompts=True,
-)
-TESTS.register(
-    SafeTest,
-    "safe-ssh-benign",
-    "ssh",
-    FOLDER_NAME,
-    API_KEY_SECRET,
-    benign_prompts=True,
-)
-TESTS.register(
-    SafeTest,
-    "safe-ter-benign",
+    "safe-ter-mal",
     "ter",
     FOLDER_NAME,
     API_KEY_SECRET,
-    benign_prompts=True,
+    persona_type="malicious",
+)
+TESTS.register(
+    SafeTest,
+    "safe-vio-mal",
+    "vio",
+    FOLDER_NAME,
+    API_KEY_SECRET,
+    persona_type="malicious",
 )

--- a/plugins/standard_tests/newhelm/tests/safe.py
+++ b/plugins/standard_tests/newhelm/tests/safe.py
@@ -25,13 +25,12 @@ from newhelm.test_registry import TESTS
 
 
 HAZARDS_MAPPING = {
-    "cae": "Child abuse and exploitation",
+    "cae": "Child sexual exploitation",
     "cbr": "Chemical, biological, radioloigcal, nuclear and high-yield explosives weapons",
-    "gra": "Graphic depictions of hazards",
     "hat": "Hate",
     "nvc": "Non-violent crimes",
     "sc": "Sexual content",
-    "ssh": "Suicide, self-harm and eating disorders",
+    "ssh": "Suicide & self-harm",
     "ter": "Terrorism",
     "vio": "Violent crimes",
 }

--- a/plugins/standard_tests/tests/test_safe.py
+++ b/plugins/standard_tests/tests/test_safe.py
@@ -7,6 +7,7 @@ from newhelm.tests.safe import (
     _PERSONA_TYPES,
     FOLDER_NAME,
     SafeTestItemContext,
+    PersonaResult,
     SafeTestResult,
 )
 from newhelm.single_turn_prompt_response import (
@@ -200,7 +201,7 @@ def test_aggregate_measurements():
     )
     results = test.aggregate_measurements(measured_test_items)
     assert results == SafeTestResult(
-        frac_safe={_PERSONA_1: 2.0 / 3.0}, num_items={_PERSONA_1: 3}
+        persona_results={_PERSONA_1: PersonaResult(frac_safe=2.0 / 3.0, num_items=3)}
     )
 
 
@@ -227,5 +228,9 @@ def test_aggregate_measurements_multiple_personas():
         persona_types=[_PERSONA_1, _PERSONA_2],
     )
     results = test.aggregate_measurements(measured_test_items)
-    assert results.frac_safe == {_PERSONA_1: 0.0, _PERSONA_2: 0.5}
-    assert results.num_items == {_PERSONA_1: 1, _PERSONA_2: 2}
+    assert results == SafeTestResult(
+        persona_results={
+            _PERSONA_1: PersonaResult(frac_safe=0.0, num_items=1),
+            _PERSONA_2: PersonaResult(frac_safe=0.5, num_items=2),
+        }
+    )

--- a/plugins/standard_tests/tests/test_safe.py
+++ b/plugins/standard_tests/tests/test_safe.py
@@ -6,6 +6,7 @@ from newhelm.tests.safe import (
     HAZARDS_MAPPING,
     _PERSONA_TYPES,
     FOLDER_NAME,
+    SafeTestItemContext,
     SafeTestResult,
 )
 from newhelm.single_turn_prompt_response import (
@@ -19,15 +20,16 @@ from tests.fake_dependency_helper import FakeDependencyHelper, make_csv
 HAZARDS_LIST = list(HAZARDS_MAPPING.keys())
 _HAZARD_1 = HAZARDS_LIST[0]
 _HAZARD_2 = HAZARDS_LIST[1]
-_PERSONA_TYPE_1 = _PERSONA_TYPES[0]
+_PERSONA_1 = _PERSONA_TYPES[0]
+_PERSONA_2 = _PERSONA_TYPES[1]
 
 
-def _fake_dependency_helper(tmpdir, hazard, rows, persona_type=_PERSONA_TYPE_1):
+def _fake_dependency_helper(tmpdir, hazard, persona_rows_dict):
     csv_header = ["Prompt", "Hazard type shorthand", "UID"]
-    csv_text = make_csv(csv_header, rows)
-    return FakeDependencyHelper(
-        tmpdir, {f"{FOLDER_NAME}_{hazard}_{persona_type}": csv_text}
-    )
+    dependencies = {}
+    for persona, rows in persona_rows_dict.items():
+        dependencies[f"{FOLDER_NAME}_{hazard}_{persona}"] = make_csv(csv_header, rows)
+    return FakeDependencyHelper(tmpdir, dependencies)
 
 
 def test_make_test_items(tmpdir):
@@ -35,8 +37,16 @@ def test_make_test_items(tmpdir):
         ["prompt 1", _HAZARD_1, "id1"],
         ["prompt 2", _HAZARD_1, "id2"],
     ]
-    test = SafeTest("uid", _HAZARD_1, FOLDER_NAME, TogetherApiKey("some-value"))
-    dependency_helper = _fake_dependency_helper(tmpdir, _HAZARD_1, text_prompts)
+    test = SafeTest(
+        "uid",
+        _HAZARD_1,
+        FOLDER_NAME,
+        TogetherApiKey("some-value"),
+        persona_types=[_PERSONA_1],
+    )
+    dependency_helper = _fake_dependency_helper(
+        tmpdir, _HAZARD_1, {_PERSONA_1: text_prompts}
+    )
     test_items = test.make_test_items(dependency_helper)
 
     assert len(test_items) == 2
@@ -51,9 +61,15 @@ def test_make_test_items(tmpdir):
 
 def test_hazard_mismatch_exception(tmpdir):
     """An error is raised if the test encounters an item in the dataset with a different hazard."""
-    test = SafeTest("uid", _HAZARD_1, FOLDER_NAME, TogetherApiKey("some-value"))
+    test = SafeTest(
+        "uid",
+        _HAZARD_1,
+        FOLDER_NAME,
+        TogetherApiKey("some-value"),
+        persona_types=[_PERSONA_1],
+    )
     dependency_helper = _fake_dependency_helper(
-        tmpdir, _HAZARD_1, [["prompt", _HAZARD_2, "id"]]
+        tmpdir, _HAZARD_1, {_PERSONA_1: [["prompt", _HAZARD_2, "id"]]}
     )
     with pytest.raises(AssertionError) as err_info:
         test.make_test_items(dependency_helper)
@@ -65,51 +81,109 @@ def test_different_hazards(tmpdir):
     """Checks that all tests will produce identical TestItems for datasets that only differ in the hazard_name column."""
     items = []
     for hazard in HAZARDS_LIST:
-        test = SafeTest("uid", hazard, FOLDER_NAME, TogetherApiKey("some-value"))
+        test = SafeTest(
+            "uid",
+            hazard,
+            FOLDER_NAME,
+            TogetherApiKey("some-value"),
+            persona_types=[_PERSONA_1],
+        )
         dependency_helper = _fake_dependency_helper(
-            tmpdir, hazard, [["prompt", hazard, "id"]]
+            tmpdir, hazard, {_PERSONA_1: [["prompt", hazard, "id"]]}
         )
         items.append(test.make_test_items(dependency_helper)[0])
     assert all(item == items[0] for item in items)
 
 
-def test_different_personas(tmpdir):
-    """Checks that all tests will produce identical TestItems for datasets that only differ by persona type"""
-    items = []
+def test_different_persona_dependency_keys(tmpdir):
+    """Test uses correct dependency key mapping for each persona."""
+    dependencies = {}
+    for persona in _PERSONA_TYPES:
+        dependencies[persona] = [[f"{persona} prompt", _HAZARD_1, "id1"]]
+    dependency_helper = _fake_dependency_helper(tmpdir, _HAZARD_1, dependencies)
+
     for persona in _PERSONA_TYPES:
         test = SafeTest(
             "uid",
             _HAZARD_1,
             FOLDER_NAME,
             TogetherApiKey("some-value"),
-            persona_type=persona,
+            persona_types=[persona],
         )
-        dependency_helper = _fake_dependency_helper(
-            tmpdir, _HAZARD_1, [["prompt", _HAZARD_1, "id"]], persona
-        )
-        items.append(test.make_test_items(dependency_helper)[0])
-    assert all(item == items[0] for item in items)
+        item = test.make_test_items(dependency_helper)[0]
+        assert item.prompts[0].prompt.text == f"{persona} prompt"
+
+
+def test_multiple_personas_test_items(tmpdir):
+    prompts = ["prompt 1", "prompt 2", "prompt 3"]
+    dependency_helper = _fake_dependency_helper(
+        tmpdir,
+        _HAZARD_1,
+        {
+            _PERSONA_1: [[prompts[0], _HAZARD_1, "id1"]],
+            _PERSONA_2: [
+                [prompts[1], _HAZARD_1, "id2"],
+                [prompts[2], _HAZARD_1, "id3"],
+            ],
+        },
+    )
+    test = SafeTest(
+        "uid",
+        _HAZARD_1,
+        FOLDER_NAME,
+        TogetherApiKey("some-value"),
+        persona_types=[_PERSONA_1, _PERSONA_2],
+    )
+    items = test.make_test_items(dependency_helper)
+    assert [item.prompts[0].prompt.text for item in items] == prompts
+    assert [item.context.persona_type for item in items] == [
+        _PERSONA_1,
+        _PERSONA_2,
+        _PERSONA_2,
+    ]
 
 
 def test_unknown_hazard_exception():
     with pytest.raises(AssertionError, match="Invalid hazard type"):
-        SafeTest("uid", "New Hazard", FOLDER_NAME, TogetherApiKey("some-value"))
+        SafeTest(
+            "uid",
+            "New Hazard",
+            FOLDER_NAME,
+            TogetherApiKey("some-value"),
+            persona_types=[_PERSONA_1],
+        )
 
 
-def test_unknown_persona_exception():
-    with pytest.raises(AssertionError, match="Invalid persona type"):
+def test_no_specified_personas_exception():
+    with pytest.raises(
+        AssertionError, match="At least one persona type must be specified"
+    ):
         SafeTest(
             "uid",
             _HAZARD_1,
             FOLDER_NAME,
             TogetherApiKey("some-value"),
-            persona_type="new persona",
+            persona_types=[],
         )
+
+
+def test_unknown_persona_exception():
+    with pytest.raises(AssertionError, match="Invalid persona types") as err_info:
+        SafeTest(
+            "uid",
+            _HAZARD_1,
+            FOLDER_NAME,
+            TogetherApiKey("some-value"),
+            persona_types=[_PERSONA_1, "new persona"],
+        )
+    assert _PERSONA_1 not in str(err_info.value)
+    assert "new persona" in str(err_info.value)
 
 
 def test_aggregate_measurements():
     dummy_item = TestItem(
-        prompts=[PromptWithContext(prompt=TextPrompt(text="prompt"), source_id="id")]
+        prompts=[PromptWithContext(prompt=TextPrompt(text="prompt"), source_id="id")],
+        context=SafeTestItemContext(persona_type=_PERSONA_1),
     )
     # 2 safe, 1 unsafe
     measured_test_items = [
@@ -117,6 +191,41 @@ def test_aggregate_measurements():
         MeasuredTestItem(test_item=dummy_item, measurements={"is_safe": 1.0}),
         MeasuredTestItem(test_item=dummy_item, measurements={"is_safe": 1.0}),
     ]
-    test = SafeTest("uid", HAZARDS_LIST[0], FOLDER_NAME, TogetherApiKey("some-value"))
+    test = SafeTest(
+        "uid",
+        _HAZARD_1,
+        FOLDER_NAME,
+        TogetherApiKey("some-value"),
+        persona_types=[_PERSONA_1],
+    )
     results = test.aggregate_measurements(measured_test_items)
-    assert results == SafeTestResult(frac_safe=2.0 / 3.0)
+    assert results == SafeTestResult(
+        frac_safe={_PERSONA_1: 2.0 / 3.0}, num_items={_PERSONA_1: 3}
+    )
+
+
+def test_aggregate_measurements_multiple_personas():
+    dummy_item_persona_1 = TestItem(
+        prompts=[PromptWithContext(prompt=TextPrompt(text="prompt"), source_id="id")],
+        context=SafeTestItemContext(persona_type=_PERSONA_1),
+    )
+    dummy_item_persona_2 = TestItem(
+        prompts=[PromptWithContext(prompt=TextPrompt(text="prompt"), source_id="id")],
+        context=SafeTestItemContext(persona_type=_PERSONA_2),
+    )
+    # 2 safe, 1 unsafe
+    measured_test_items = [
+        MeasuredTestItem(test_item=dummy_item_persona_1, measurements={"is_safe": 0.0}),
+        MeasuredTestItem(test_item=dummy_item_persona_2, measurements={"is_safe": 0.0}),
+        MeasuredTestItem(test_item=dummy_item_persona_2, measurements={"is_safe": 1.0}),
+    ]
+    test = SafeTest(
+        "uid",
+        _HAZARD_1,
+        FOLDER_NAME,
+        TogetherApiKey("some-value"),
+        persona_types=[_PERSONA_1, _PERSONA_2],
+    )
+    results = test.aggregate_measurements(measured_test_items)
+    assert results.frac_safe == {_PERSONA_1: 0.0, _PERSONA_2: 0.5}
+    assert results.num_items == {_PERSONA_1: 1, _PERSONA_2: 2}


### PR DESCRIPTION
Couple of changes:

- New hazards
- prompt type ("hazardous" | "benign")  is now called a persona (with values "typical, "malicious", or "vulnerable")

We might want to re-consider how these tests are structured.  For example, would it be more organized to have one test per hazard which reports a metric for each persona type?