### PR TITLE
Make persona type Enum

### DIFF
--- a/plugins/standard_tests/newhelm/tests/safe.py
+++ b/plugins/standard_tests/newhelm/tests/safe.py
@@ -1,5 +1,6 @@
 import csv
-from typing import List, Dict, Mapping
+from enum import Enum
+from typing import Any, List, Dict, Mapping
 
 from newhelm.annotators.llama_guard_annotator import (
     LlamaGuardAnnotation,
@@ -35,11 +36,16 @@ HAZARDS_MAPPING = {
     "ter": "Terrorism",
     "vio": "Violent crimes",
 }
-_PERSONA_TYPES = ["typical", "malicious", "vulnerable"]
+
+
+class PersonaType(str, Enum):
+    typical = "typical"
+    malicious = "malicious"
+    vulnerable = "vulnerable"
 
 
 class SafeTestItemContext(BaseModel):
-    persona_type: str
+    persona_type: PersonaType
 
 
 class PersonaResult(BaseModel):
@@ -48,7 +54,7 @@ class PersonaResult(BaseModel):
 
 
 class SafeTestResult(BaseModel):
-    persona_results: Mapping[str, PersonaResult]
+    persona_results: Mapping[PersonaType, PersonaResult]
 
 
 @newhelm_test(requires_sut_capabilities=[AcceptsTextPrompt])
@@ -59,25 +65,30 @@ class SafeTest(BasePromptResponseTest):
         hazard: str,
         folder_name: str,
         together_api_key: TogetherApiKey,
-        persona_types: List[str],
+        persona_types: List[PersonaType],
     ):
         super().__init__(uid)
         assert hazard in HAZARDS_MAPPING, f"Invalid hazard type {hazard}."
-        invalid_personas = [
-            persona for persona in persona_types if persona not in _PERSONA_TYPES
-        ]
-        assert len(invalid_personas) == 0, f"Invalid persona types {invalid_personas}."
-        assert len(persona_types), "At least one persona type must be specified."
-        assert len(persona_types) == len(
-            set(persona_types)
-        ), "Persona types may not contain duplicates."
         self.hazard = hazard
         self.hazard_name = HAZARDS_MAPPING[hazard]
         self.folder_name = folder_name
         self.together_api_key = together_api_key
-        self.persona_types = persona_types
+        self.persona_types: List[PersonaType] = []
+        invalid_personas: List[Any] = []
+        for persona in persona_types:
+            if not isinstance(persona, PersonaType):
+                try:
+                    persona = PersonaType(persona)
+                except ValueError:
+                    invalid_personas.append(persona)
+            assert (
+                persona not in self.persona_types
+            ), "Persona types may not contain duplicates."
+            self.persona_types.append(persona)
+        assert len(invalid_personas) == 0, f"Invalid persona types {invalid_personas}."
+        assert len(persona_types), "At least one persona type must be specified."
 
-    def _persona_dependency_key(self, persona: str) -> str:
+    def _persona_dependency_key(self, persona: PersonaType) -> str:
         return f"{self.folder_name}_{self.hazard}_{persona}"
 
     def get_dependencies(self) -> Mapping[str, ExternalData]:
@@ -140,10 +151,10 @@ class SafeTest(BasePromptResponseTest):
             "is_safe", items, key=lambda item: item.test_item.context.persona_type
         )
         persona_results = {}
-        for persona, persona_measurements in measurement_stats.items():
+        for persona in self.persona_types:
             persona_results[persona] = PersonaResult(
-                frac_safe=persona_measurements.mean,
-                num_items=persona_measurements.count,
+                frac_safe=measurement_stats[persona].mean,
+                num_items=measurement_stats[persona].count,
             )
         return SafeTestResult(persona_results=persona_results)
 
@@ -156,7 +167,7 @@ TESTS.register(
     "cae",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=["typical", "malicious"],
+    persona_types=[PersonaType.typical, PersonaType.malicious],
 )
 TESTS.register(
     SafeTest,
@@ -164,7 +175,7 @@ TESTS.register(
     "cbr",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=["malicious"],
+    persona_types=[PersonaType.malicious],
 )
 TESTS.register(
     SafeTest,
@@ -172,7 +183,7 @@ TESTS.register(
     "hat",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=["typical", "malicious"],
+    persona_types=[PersonaType.typical, PersonaType.malicious],
 )
 TESTS.register(
     SafeTest,
@@ -180,7 +191,7 @@ TESTS.register(
     "nvc",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=["typical", "malicious"],
+    persona_types=[PersonaType.typical, PersonaType.malicious],
 )
 TESTS.register(
     SafeTest,
@@ -188,7 +199,7 @@ TESTS.register(
     "sc",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=["typical", "malicious"],
+    persona_types=[PersonaType.typical, PersonaType.malicious],
 )
 TESTS.register(
     SafeTest,
@@ -196,7 +207,7 @@ TESTS.register(
     "ssh",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=["typical", "vulnerable"],
+    persona_types=[PersonaType.typical, PersonaType.vulnerable],
 )
 TESTS.register(
     SafeTest,
@@ -204,7 +215,7 @@ TESTS.register(
     "ter",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=["typical", "malicious"],
+    persona_types=[PersonaType.typical, PersonaType.malicious],
 )
 TESTS.register(
     SafeTest,
@@ -212,5 +223,5 @@ TESTS.register(
     "vio",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=["malicious"],
+    persona_types=[PersonaType.malicious],
 )

--- a/plugins/standard_tests/newhelm/tests/safe.py
+++ b/plugins/standard_tests/newhelm/tests/safe.py
@@ -39,9 +39,9 @@ HAZARDS_MAPPING = {
 
 
 class PersonaType(str, Enum):
-    typical = "typical"
-    malicious = "malicious"
-    vulnerable = "vulnerable"
+    TYPICAL = "typical"
+    MALICIOUS = "malicious"
+    VULNERABLE = "vulnerable"
 
 
 class SafeTestItemContext(BaseModel):
@@ -167,7 +167,7 @@ TESTS.register(
     "cae",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=[PersonaType.typical, PersonaType.malicious],
+    persona_types=[PersonaType.TYPICAL, PersonaType.MALICIOUS],
 )
 TESTS.register(
     SafeTest,
@@ -175,7 +175,7 @@ TESTS.register(
     "cbr",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=[PersonaType.malicious],
+    persona_types=[PersonaType.MALICIOUS],
 )
 TESTS.register(
     SafeTest,
@@ -183,7 +183,7 @@ TESTS.register(
     "hat",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=[PersonaType.typical, PersonaType.malicious],
+    persona_types=[PersonaType.TYPICAL, PersonaType.MALICIOUS],
 )
 TESTS.register(
     SafeTest,
@@ -191,7 +191,7 @@ TESTS.register(
     "nvc",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=[PersonaType.typical, PersonaType.malicious],
+    persona_types=[PersonaType.TYPICAL, PersonaType.MALICIOUS],
 )
 TESTS.register(
     SafeTest,
@@ -199,7 +199,7 @@ TESTS.register(
     "sc",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=[PersonaType.typical, PersonaType.malicious],
+    persona_types=[PersonaType.TYPICAL, PersonaType.MALICIOUS],
 )
 TESTS.register(
     SafeTest,
@@ -207,7 +207,7 @@ TESTS.register(
     "ssh",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=[PersonaType.typical, PersonaType.vulnerable],
+    persona_types=[PersonaType.TYPICAL, PersonaType.VULNERABLE],
 )
 TESTS.register(
     SafeTest,
@@ -215,7 +215,7 @@ TESTS.register(
     "ter",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=[PersonaType.typical, PersonaType.malicious],
+    persona_types=[PersonaType.TYPICAL, PersonaType.MALICIOUS],
 )
 TESTS.register(
     SafeTest,
@@ -223,5 +223,5 @@ TESTS.register(
     "vio",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=[PersonaType.malicious],
+    persona_types=[PersonaType.MALICIOUS],
 )

--- a/plugins/standard_tests/newhelm/tests/safe.py
+++ b/plugins/standard_tests/newhelm/tests/safe.py
@@ -73,20 +73,8 @@ class SafeTest(BasePromptResponseTest):
         self.hazard_name = HAZARDS_MAPPING[hazard]
         self.folder_name = folder_name
         self.together_api_key = together_api_key
-        self.persona_types: List[PersonaType] = []
-        invalid_personas: List[Any] = []
-        for persona in persona_types:
-            if not isinstance(persona, PersonaType):
-                try:
-                    persona = PersonaType(persona)
-                except ValueError:
-                    invalid_personas.append(persona)
-            assert (
-                persona not in self.persona_types
-            ), "Persona types may not contain duplicates."
-            self.persona_types.append(persona)
-        assert len(invalid_personas) == 0, f"Invalid persona types {invalid_personas}."
         assert len(persona_types), "At least one persona type must be specified."
+        self.persona_types: List[PersonaType] = list(set(persona_types))
 
     def _persona_dependency_key(self, persona: PersonaType) -> str:
         return f"{self.folder_name}_{self.hazard}_{persona}"

--- a/plugins/standard_tests/tests/test_safe.py
+++ b/plugins/standard_tests/tests/test_safe.py
@@ -21,8 +21,8 @@ from tests.fake_dependency_helper import FakeDependencyHelper, make_csv
 HAZARDS_LIST = list(HAZARDS_MAPPING.keys())
 _HAZARD_1 = HAZARDS_LIST[0]
 _HAZARD_2 = HAZARDS_LIST[1]
-_PERSONA_1 = PersonaType.typical
-_PERSONA_2 = PersonaType.malicious
+_PERSONA_1 = PersonaType.TYPICAL
+_PERSONA_2 = PersonaType.MALICIOUS
 
 
 def _fake_dependency_helper(tmpdir, hazard, persona_rows_dict):
@@ -132,7 +132,7 @@ def test_string_personas(tmpdir):
         _HAZARD_1,
         FOLDER_NAME,
         TogetherApiKey("some-value"),
-        persona_types=[PersonaType.typical],
+        persona_types=[PersonaType.TYPICAL],
     )
     assert string_persona_test.persona_types == enum_persona_test.persona_types
     assert (
@@ -271,7 +271,7 @@ def test_result_keyable_with_string_or_enum_persona(tmpdir):
                         prompt=TextPrompt(text="typical prompt"), source_id="id1"
                     )
                 ],
-                context=SafeTestItemContext(persona_type=PersonaType.typical),
+                context=SafeTestItemContext(persona_type=PersonaType.TYPICAL),
             ),
             measurements={"is_safe": 0.0},
         ),
@@ -282,7 +282,7 @@ def test_result_keyable_with_string_or_enum_persona(tmpdir):
                         prompt=TextPrompt(text="malicious prompt"), source_id="id2"
                     )
                 ],
-                context=SafeTestItemContext(persona_type=PersonaType.malicious),
+                context=SafeTestItemContext(persona_type=PersonaType.MALICIOUS),
             ),
             measurements={"is_safe": 1.0},
         ),
@@ -292,8 +292,8 @@ def test_result_keyable_with_string_or_enum_persona(tmpdir):
         _HAZARD_1,
         FOLDER_NAME,
         TogetherApiKey("some-value"),
-        persona_types=[PersonaType.typical, PersonaType.malicious],
+        persona_types=[PersonaType.TYPICAL, PersonaType.MALICIOUS],
     )
     persona_results = test.aggregate_measurements(measured_test_items).persona_results
-    assert persona_results[PersonaType.typical] == persona_results["typical"]
-    assert persona_results[PersonaType.malicious] == persona_results["malicious"]
+    assert persona_results[PersonaType.TYPICAL] == persona_results["typical"]
+    assert persona_results[PersonaType.MALICIOUS] == persona_results["malicious"]

--- a/plugins/standard_tests/tests/test_safe.py
+++ b/plugins/standard_tests/tests/test_safe.py
@@ -162,7 +162,6 @@ def test_multiple_personas_test_items(tmpdir):
         persona_types=[_PERSONA_1, _PERSONA_2],
     )
     items = test.make_test_items(dependency_helper)
-    assert [item.prompts[0].prompt.text for item in items] == prompts
     assert {
         (item.prompts[0].prompt.text, item.context.persona_type) for item in items
     } == set(zip(prompts, [_PERSONA_1, _PERSONA_2, _PERSONA_2]))


### PR DESCRIPTION
This PR makes persona types an Enum in SafeTest. You can still use regular strings in the test initialization to key the persona_results dictionary, so this should not require any changes to existing code that uses these tests.