### PR TITLE
Fix warning for pad token

### DIFF
--- a/plugins/huggingface/newhelm/suts/huggingface_client.py
+++ b/plugins/huggingface/newhelm/suts/huggingface_client.py
@@ -357,12 +357,14 @@ class HuggingFaceSUT(PromptResponseSUT[HuggingFaceRequest, HuggingFaceResponse])
             sequences = encoded_input["input_ids"]
             scores = output.logits
         else:
-            generation_config = (
-                GenerationConfig(pad_token_id=self.model.config.eos_token_id)
-                if self.model.config.pad_token_id is None
-                and self.model.config.eos_token_id is not None
-                else None
-            )
+            # Some models do not have a `pad_token_id`. For example gpt2
+            # This prevents a warning message
+            generation_config = None
+            if self.model.config.pad_token_id is None:
+                if self.model.config.eos_token_id is not None:
+                    generation_config = GenerationConfig(
+                        pad_token_id=self.model.config.eos_token_id
+                    )
             output = self.model.generate(
                 **encoded_input,
                 temperature=raw_request.temperature,

--- a/plugins/huggingface/newhelm/suts/huggingface_client.py
+++ b/plugins/huggingface/newhelm/suts/huggingface_client.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 import logging
 from pydantic import BaseModel
 import torch
-from transformers import AutoModelForCausalLM  # type: ignore
+from transformers import AutoModelForCausalLM, GenerationConfig  # type: ignore
 from transformers.generation.stopping_criteria import (  # type: ignore
     StoppingCriteria,
     StoppingCriteriaList,
@@ -357,6 +357,12 @@ class HuggingFaceSUT(PromptResponseSUT[HuggingFaceRequest, HuggingFaceResponse])
             sequences = encoded_input["input_ids"]
             scores = output.logits
         else:
+            generation_config = (
+                GenerationConfig(pad_token_id=self.model.config.eos_token_id)
+                if self.model.config.pad_token_id is None
+                and self.model.config.eos_token_id is not None
+                else None
+            )
             output = self.model.generate(
                 **encoded_input,
                 temperature=raw_request.temperature,
@@ -366,6 +372,7 @@ class HuggingFaceSUT(PromptResponseSUT[HuggingFaceRequest, HuggingFaceResponse])
                 do_sample=True,
                 return_dict_in_generate=True,
                 output_scores=True,
+                generation_config=generation_config,
                 **optional_args,
                 stopping_criteria=stopping_criteria,
             )


### PR DESCRIPTION
* Fix warning for pad token

```
Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.
```

* Check if `pad_token_id` is set in model config and if not, get it explicitly in `generation_config`


----

There may well be better ways to handle this. But figured I'd send it in to at least illustrate the cause of the issue.