### PR TITLE
Set up `newhelm` command to simplify command line.

### DIFF
--- a/demo_plugin/README.md
+++ b/demo_plugin/README.md
@@ -4,5 +4,5 @@ This directory contains worked examples for how to define your own Tests, and SU
 
 ```
 poetry install --extras demo
-poetry run python newhelm/main.py run-test --test demo_01 --sut demo_yes_no
+poetry run newhelm run-test --test demo_01 --sut demo_yes_no
 ```

--- a/docs/dev_quick_start.md
+++ b/docs/dev_quick_start.md
@@ -11,27 +11,27 @@ This will instruct [poetry](https://python-poetry.org/docs/) to install the defa
 For example, you can run our command line tool with:
 
 ```
-poetry run python newhelm/main.py
+poetry run newhelm
 ```
 
 That should provide you with a list of all commands available. A useful command to run is `list`, which will show you all known Tests, System Under Tests (SUTs), and installed plugins.
 
 ```
-poetry run python newhelm/main.py list
+poetry run newhelm list
 ```
 
 NewHELM uses a [plugin architecture](plugins.md), so by default the list should be pretty empty. To see this in action, we can instruct poetry to install the `demo` plugin:
 
 ```
 poetry install --extras demo
-poetry run python newhelm/main.py list
+poetry run newhelm list
 ```
 
 You should now see a list of all the modules in the `demo_plugin/` directory. For more info on the demo see [here](tutorial.md). The `plugins/` directory contains many useful plugins. However, those have a lot of transitive dependencies, so they can take a while to install. To install them all:
 
 ```
 poetry install --extras all_plugins
-poetry run python newhelm/main.py list
+poetry run newhelm list
 ```
 
 Finally note that any extras not listed in a `poetry install` call will be uninstalled.
@@ -41,18 +41,18 @@ Finally note that any extras not listed in a `poetry install` call will be unins
 Here is an example of running a Test, using the `demo` plugin:
 
 ```
-poetry run python newhelm/main.py run-test --sut demo_yes_no --test demo_01
+poetry run newhelm run-test --sut demo_yes_no --test demo_01
 ```
 
 If you want additional information about existing tests, you can run:
 
 ```
-poetry run python newhelm/main.py list-tests
+poetry run newhelm list-tests
 ```
 
 To obtain detailed information about the existing Systems Under Test (SUTs) in your setup, you can execute the following command:
 ```
-poetry run python newhelm/main.py list-suts
+poetry run newhelm list-suts
 ```
 
 # Further Questions

--- a/docs/tutorial_suts.md
+++ b/docs/tutorial_suts.md
@@ -100,13 +100,13 @@ NewHELM's [plugin architecture](plugins.md) will automatically try to import all
 With our SUT installed (either via plugin or in the local directory), we can run it manually with `run-sut`:
 
 ```
-poetry run python newhelm/main.py run-sut --sut demo_yes_no --prompt "One two three four"
+poetry run newhelm run-sut --sut demo_yes_no --prompt "One two three four"
 ```
 
 We can also evaluate it using any Test in NewHELM!
 
 ```
-poetry run python newhelm/main.py run-test --test demo_01 --sut demo_yes_no
+poetry run newhelm run-test --test demo_01 --sut demo_yes_no
 ```
 
 ## SUTs that call an API

--- a/docs/tutorial_tests.md
+++ b/docs/tutorial_tests.md
@@ -55,7 +55,7 @@ NewHELM's [plugin architecture](plugins.md) will automatically try to import all
 With our SUT installed (either via plugin or in the local directory), we can run it against any SUT in NewHELM!
 
 ```
-poetry run python newhelm/main.py run-test --test demo_01 --sut demo_yes_no
+poetry run newhelm run-test --test demo_01 --sut demo_yes_no
 ```
 
 ## Dealing with data dependencies

--- a/newhelm/load_plugins.py
+++ b/newhelm/load_plugins.py
@@ -4,9 +4,9 @@ This namespace plugin loader will discover and load all plugins from newhelm's p
 To see this in action:
 
 * poetry install
-* poetry run python newhelm/main.py list
+* poetry run newhelm list
 * poetry install --extras demo
-* poetry run python newhelm/main.py list
+* poetry run newhelm list
 
 The demo plugin modules will only print on the second run.
 """

--- a/newhelm/main.py
+++ b/newhelm/main.py
@@ -150,6 +150,10 @@ def run_sut(
     click.echo(f"Normalized response: {result.model_dump_json(indent=2)}\n")
 
 
-if __name__ == "__main__":
+def main():
     load_plugins()
     newhelm_cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,6 @@ priority = "explicit"
 
 [[tool.poetry_bumpversion.replacements]]
 files = ["demo_plugin/pyproject.toml", "plugins/huggingface/pyproject.toml", "plugins/openai/pyproject.toml", "plugins/perspective_api/pyproject.toml", "plugins/standard_tests/pyproject.toml", "plugins/together/pyproject.toml"]
+
+[tool.poetry.scripts]
+newhelm = "newhelm.main:main"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,34 +6,29 @@ import pytest
 from tests.utilities import expensive_tests
 
 
-@pytest.fixture
-def cmd():
-    return pathlib.Path(__file__).parent.parent / "newhelm" / "main.py"
+@expensive_tests
+def test_main():
+    assert os.system("newhelm") == 0
 
 
 @expensive_tests
-def test_main(cmd):
-    assert os.system(f"python {cmd}") == 0
+def test_list_plugins():
+    assert os.system("newhelm list") == 0
 
 
 @expensive_tests
-def test_list_plugins(cmd):
-    assert os.system(f"python {cmd} list") == 0
+def test_list_secrets():
+    assert os.system("newhelm list-secrets") == 0
 
 
 @expensive_tests
-def test_list_secrets(cmd):
-    assert os.system(f"python {cmd} list-secrets") == 0
+def test_list_tests():
+    assert os.system("newhelm list-tests") == 0
 
 
 @expensive_tests
-def test_list_tests(cmd):
-    assert os.system(f"python {cmd} list-tests") == 0
-
-
-@expensive_tests
-def test_list_suts(cmd):
-    assert os.system(f"python {cmd} list-suts") == 0
+def test_list_suts():
+    assert os.system("newhelm list-suts") == 0
 
 
 @expensive_tests
@@ -46,10 +41,10 @@ def test_list_suts(cmd):
         "demo_always_sorry",
     ],
 )
-def test_run_sut_demos(cmd, sut):
+def test_run_sut_demos(sut):
     assert (
         os.system(
-            f"""python {cmd} run-sut \
+            f"""newhelm run-sut \
                 --sut {sut} \
                 --prompt "Can you say Hello?" """
         )
@@ -59,10 +54,10 @@ def test_run_sut_demos(cmd, sut):
 
 @expensive_tests
 @pytest.mark.parametrize("test", ["demo_01", "demo_02", "demo_03", "demo_04"])
-def test_run_test_demos(cmd, test):
+def test_run_test_demos(test):
     assert (
         os.system(
-            f"""python {cmd} run-test \
+            f"""newhelm run-test \
                 --test {test} \
                 --sut demo_yes_no \
                 --max-test-items 1"""


### PR DESCRIPTION
Going from 5 words (poetry run python newhelm/main.py) to 3 (poetry run newhelm).