### PR TITLE
SafeTest data 29mar2024 release

### DIFF
--- a/plugins/standard_tests/newhelm/tests/safe.py
+++ b/plugins/standard_tests/newhelm/tests/safe.py
@@ -135,12 +135,13 @@ class SafeTest(BasePromptResponseTest):
     def aggregate_measurements(self, items: List[MeasuredTestItem]) -> SafeTestResult:
         """
         Returns a SafeTestResult that maps each persona_type's subset of prompts to its corresponding measurements.
+        Persona types that do not have any measured test items are not included.
         """
         measurement_stats = get_measurement_stats_by_key(
             "is_safe", items, key=lambda item: item.test_item.context.persona_type
         )
         persona_results = {}
-        for persona in self.persona_types:
+        for persona in measurement_stats:
             persona_results[persona] = PersonaResult(
                 frac_safe=measurement_stats[persona].mean,
                 num_items=measurement_stats[persona].count,

--- a/plugins/standard_tests/newhelm/tests/safe.py
+++ b/plugins/standard_tests/newhelm/tests/safe.py
@@ -55,7 +55,7 @@ class PersonaResult(BaseModel):
 
 
 class SafeTestResult(BaseModel):
-    persona_results: Mapping[str, PersonaResult]
+    persona_results: Mapping[PersonaType, PersonaResult]
 
 
 @newhelm_test(requires_sut_capabilities=[AcceptsTextPrompt])
@@ -141,11 +141,12 @@ class SafeTest(PromptResponseTest):
             "is_safe", items, key=lambda item: item.test_item.context.persona_type
         )
         persona_results = {}
-        for persona in measurement_stats:
-            persona_results[persona] = PersonaResult(
-                frac_safe=measurement_stats[persona].mean,
-                num_items=measurement_stats[persona].count,
-            )
+        for persona in self.persona_types:
+            if persona in measurement_stats:
+                persona_results[persona] = PersonaResult(
+                    frac_safe=measurement_stats[persona].mean,
+                    num_items=measurement_stats[persona].count,
+                )
         return SafeTestResult(persona_results=persona_results)
 
 

--- a/plugins/standard_tests/tests/test_safe.py
+++ b/plugins/standard_tests/tests/test_safe.py
@@ -26,7 +26,7 @@ _PERSONA_2 = PersonaType.MALICIOUS
 
 
 def _fake_dependency_helper(tmpdir, hazard, persona_rows_dict):
-    csv_header = ["Prompt", "Hazard type shorthand", "UID"]
+    csv_header = ["prompt", "Hazard category shorthand", "UID"]
     dependencies = {}
     for persona, rows in persona_rows_dict.items():
         dependencies[f"{FOLDER_NAME}_{hazard}_{persona}"] = make_csv(csv_header, rows)


### PR DESCRIPTION
- No runtime error if there are no measured tests items associated with one of the test’s persona (e.g. when setting `—max-test-items`)
- More prompts
- New test safe-ben, which consists of benign prompts for the typical persona. It is intended to test genuine should-never-be-unsafe cases.
- Some changes in the hazard taxonomy. These are the final hazards for v0.5.
- Terrorism is now grouped with violent crimes
- Violent crimes shorthand changed from vio → vc