### PR TITLE
SafeData release 02apr2024

### DIFF
--- a/plugins/standard_tests/newhelm/tests/safe.py
+++ b/plugins/standard_tests/newhelm/tests/safe.py
@@ -30,10 +30,10 @@ HAZARDS_MAPPING = {
     "cbr": "Chemical, biological, radioloigcal, nuclear and high-yield explosives weapons",
     "hat": "Hate",
     "nvc": "Non-violent crimes",
-    "sc": "Sex crimes",
+    "scr": "Sex crimes",
     "ssh": "Suicide & self-harm",
     "ter": "Terrorism",
-    "vc": "Violent crimes",
+    "vcr": "Violent crimes",
 }
 
 
@@ -100,7 +100,7 @@ class SafeTest(PromptResponseTest):
             with open(data_file, "r") as csvfile:
                 reader = csv.DictReader(csvfile)
                 for row in reader:
-                    text = row["prompt"].strip()
+                    text = row["Prompt"].strip()
                     if not text:
                         continue
                     file_hazard = row["Hazard category shorthand"]
@@ -148,7 +148,7 @@ class SafeTest(PromptResponseTest):
         return SafeTestResult(persona_results=persona_results)
 
 
-FOLDER_NAME = "data_29mar2024"
+FOLDER_NAME = "data_02apr2024"
 API_KEY_SECRET = InjectSecret(TogetherApiKey)
 TESTS.register(
     SafeTest,
@@ -193,8 +193,8 @@ TESTS.register(
 )
 TESTS.register(
     SafeTest,
-    "safe-sc",
-    "sc",
+    "safe-scr",
+    "scr",
     FOLDER_NAME,
     API_KEY_SECRET,
     persona_types=[PersonaType.TYPICAL, PersonaType.MALICIOUS],
@@ -209,8 +209,8 @@ TESTS.register(
 )
 TESTS.register(
     SafeTest,
-    "safe-vc",
-    "vc",
+    "safe-vcr",
+    "vcr",
     FOLDER_NAME,
     API_KEY_SECRET,
     persona_types=[PersonaType.TYPICAL, PersonaType.MALICIOUS],

--- a/plugins/standard_tests/tests/test_safe.py
+++ b/plugins/standard_tests/tests/test_safe.py
@@ -25,7 +25,7 @@ _PERSONA_2 = PersonaType.MALICIOUS
 
 
 def _fake_dependency_helper(tmpdir, hazard, persona_rows_dict):
-    csv_header = ["prompt", "Hazard category shorthand", "UID"]
+    csv_header = ["Prompt", "Hazard category shorthand", "UID"]
     dependencies = {}
     for persona, rows in persona_rows_dict.items():
         dependencies[f"{FOLDER_NAME}_{hazard}_{persona}"] = make_csv(csv_header, rows)


### PR DESCRIPTION
Shorthand changes:
- sc --> scr
- vc --> vcr

New dataset sizes

- **safe-ben** 480
- **safe-cae** 250
- **safe-cbr** 2290
- **safe-hat** 27250
- **safe-nvc** 2530
- **safe-scr** 2050
- **safe-ssh** 1810
- **safe-vcr** 5110