### PR TITLE
`max_test_items` returns a relatively stable set of prompts

### DIFF
--- a/newhelm/runners/simple_test_runner.py
+++ b/newhelm/runners/simple_test_runner.py
@@ -74,7 +74,8 @@ def run_prompt_response_test(
         if max_test_items < len(test_items):
             rng = random.Random()
             rng.seed(0)
-            test_items = rng.sample(test_items, max_test_items)
+            rng.shuffle(test_items)
+            test_items = test_items[:max_test_items]
     test_item_records = []
     measured_test_items = []
     desc = f"Processing TestItems for test={test.uid} sut={sut.uid}"

--- a/tests/runners/test_simple_test_runner.py
+++ b/tests/runners/test_simple_test_runner.py
@@ -1,4 +1,5 @@
 import pytest
+
 from newhelm.annotation import Annotation
 from newhelm.records import TestItemRecord
 from newhelm.runners.simple_test_runner import run_prompt_response_test
@@ -150,6 +151,7 @@ def test_run_prompt_response_test_ignore_caching(tmpdir):
     assert record_1.test_item_records == record_2.test_item_records
     assert record_1.result == record_2.result
 
+
 def fake_run(max_test_items, tmpdir):
     # Lots of test items
     test_items = [fake_test_item(str(i)) for i in range(100)]
@@ -185,9 +187,6 @@ def test_run_prompt_response_test_max_test_items_stable(tmpdir):
 
     for p in prompts3:
         assert p in prompts4
-
-
-
 
 
 def test_run_prompt_response_test_max_test_items_zero(tmpdir):
@@ -272,7 +271,7 @@ def test_run_prompt_response_test_invalid_test(tmpdir):
             tmpdir,
         )
     assert (
-        str(err_info.value) == "NotATestOrSut should be decorated with @newhelm_test."
+            str(err_info.value) == "NotATestOrSut should be decorated with @newhelm_test."
     )
 
 

--- a/tests/runners/test_simple_test_runner.py
+++ b/tests/runners/test_simple_test_runner.py
@@ -150,8 +150,7 @@ def test_run_prompt_response_test_ignore_caching(tmpdir):
     assert record_1.test_item_records == record_2.test_item_records
     assert record_1.result == record_2.result
 
-
-def test_run_prompt_response_test_max_test_items(tmpdir):
+def fake_run(max_test_items, tmpdir):
     # Lots of test items
     test_items = [fake_test_item(str(i)) for i in range(100)]
     fake_measurement = {"some-measurement": 0.5}
@@ -164,10 +163,31 @@ def test_run_prompt_response_test_max_test_items(tmpdir):
         FakeSUT(),
         tmpdir,
         # Limit to just 3 test items
-        max_test_items=3,
+        max_test_items=max_test_items,
     )
-    assert len(record.test_item_records) == 3
+    return record
+
+
+def test_run_prompt_response_test_max_test_items(tmpdir):
+    max_test_items = 3
+    record = fake_run(max_test_items, tmpdir)
+    assert len(record.test_item_records) == max_test_items
     assert record.result.to_instance() == FakeTestResult(count_test_items=3.0)
+
+
+def test_run_prompt_response_test_max_test_items_stable(tmpdir):
+    run3 = fake_run(3, tmpdir)
+    run4 = fake_run(4, tmpdir)
+    prompts3 = [r.test_item.prompts[0].prompt.text for r in run3.test_item_records]
+    prompts4 = [r.test_item.prompts[0].prompt.text for r in run4.test_item_records]
+    assert len(prompts3) == 3
+    assert len(prompts4) == 4
+
+    for p in prompts3:
+        assert p in prompts4
+
+
+
 
 
 def test_run_prompt_response_test_max_test_items_zero(tmpdir):

--- a/tests/runners/test_simple_test_runner.py
+++ b/tests/runners/test_simple_test_runner.py
@@ -271,7 +271,7 @@ def test_run_prompt_response_test_invalid_test(tmpdir):
             tmpdir,
         )
     assert (
-            str(err_info.value) == "NotATestOrSut should be decorated with @newhelm_test."
+        str(err_info.value) == "NotATestOrSut should be decorated with @newhelm_test."
     )
 
 


### PR DESCRIPTION
[Note: this is wrong about the old code]

For the old code, if you change the max number of prompts by 1, you might get an entirely different set of prompts. But given the speed of execution and the new size of the prompt sets (over 20k at the top end), that doesn't work very well. If I run with a `max_test_items` of 100 and then bump it to 110, I'd like it to only run 10 more items, not a mostly or entirely different 110.