### PR TITLE
Only modify `version =` statements in toml files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,8 @@ priority = "explicit"
 
 [[tool.poetry_bumpversion.replacements]]
 files = ["demo_plugin/pyproject.toml", "plugins/huggingface/pyproject.toml", "plugins/openai/pyproject.toml", "plugins/perspective_api/pyproject.toml", "plugins/standard_tests/pyproject.toml", "plugins/together/pyproject.toml"]
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
 
 [tool.poetry.scripts]
 newhelm = "newhelm.main:main"


### PR DESCRIPTION
I've confirmed this would not have caused the issue in https://github.com/mlcommons/newhelm/pull/351. There are still some potential issues:

* If you somehow have a package ending in `version` set to exactly the current version number, replacement will happen.
* If you have different white space around the equals in `version = `, replacement will not happen (but you do get a warning).
* If we have one plugin depend on another's exact version, that won't get updated anymore.

I think these issues are less bad than the current setup.