### PR TITLE
Have SafeTest produce test items in a stable order.

### DIFF
--- a/plugins/standard_tests/newhelm/tests/safe.py
+++ b/plugins/standard_tests/newhelm/tests/safe.py
@@ -22,7 +22,7 @@ from newhelm.suts.together_client import TogetherApiKey
 from newhelm.test_decorator import newhelm_test
 from newhelm.test_registry import TESTS
 from pydantic import BaseModel
-from typing import Dict, List, Mapping
+from typing import Dict, List, Mapping, Set
 
 HAZARDS_MAPPING = {
     "ben": "Benign",
@@ -64,7 +64,7 @@ class SafeTest(PromptResponseTest):
         hazard: str,
         folder_name: str,
         together_api_key: TogetherApiKey,
-        persona_types: List[PersonaType],
+        persona_types: Set[PersonaType],
     ):
         super().__init__(uid)
         assert hazard in HAZARDS_MAPPING, f"Invalid hazard type {hazard}."
@@ -73,7 +73,7 @@ class SafeTest(PromptResponseTest):
         self.folder_name = folder_name
         self.together_api_key = together_api_key
         assert len(persona_types), "At least one persona type must be specified."
-        self.persona_types: List[PersonaType] = list(set(persona_types))
+        self.persona_types: List[PersonaType] = sorted(persona_types)
 
     def _persona_dependency_key(self, persona: PersonaType) -> str:
         return f"{self.folder_name}_{self.hazard}_{persona}"
@@ -156,7 +156,7 @@ TESTS.register(
     "ben",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=[PersonaType.TYPICAL],
+    persona_types={PersonaType.TYPICAL},
 )
 
 TESTS.register(
@@ -165,7 +165,7 @@ TESTS.register(
     "cae",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=[PersonaType.TYPICAL, PersonaType.MALICIOUS],
+    persona_types={PersonaType.TYPICAL, PersonaType.MALICIOUS},
 )
 TESTS.register(
     SafeTest,
@@ -173,7 +173,7 @@ TESTS.register(
     "cbr",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=[PersonaType.TYPICAL, PersonaType.MALICIOUS],
+    persona_types={PersonaType.TYPICAL, PersonaType.MALICIOUS},
 )
 TESTS.register(
     SafeTest,
@@ -181,7 +181,7 @@ TESTS.register(
     "hat",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=[PersonaType.TYPICAL, PersonaType.MALICIOUS],
+    persona_types={PersonaType.TYPICAL, PersonaType.MALICIOUS},
 )
 TESTS.register(
     SafeTest,
@@ -189,7 +189,7 @@ TESTS.register(
     "nvc",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=[PersonaType.TYPICAL, PersonaType.MALICIOUS],
+    persona_types={PersonaType.TYPICAL, PersonaType.MALICIOUS},
 )
 TESTS.register(
     SafeTest,
@@ -197,7 +197,7 @@ TESTS.register(
     "scr",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=[PersonaType.TYPICAL, PersonaType.MALICIOUS],
+    persona_types={PersonaType.TYPICAL, PersonaType.MALICIOUS},
 )
 TESTS.register(
     SafeTest,
@@ -213,5 +213,5 @@ TESTS.register(
     "vcr",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types=[PersonaType.TYPICAL, PersonaType.MALICIOUS],
+    persona_types={PersonaType.TYPICAL, PersonaType.MALICIOUS},
 )

--- a/plugins/standard_tests/newhelm/tests/safe.py
+++ b/plugins/standard_tests/newhelm/tests/safe.py
@@ -64,7 +64,7 @@ class SafeTest(PromptResponseTest):
         hazard: str,
         folder_name: str,
         together_api_key: TogetherApiKey,
-        persona_types: Set[PersonaType],
+        persona_types: List[PersonaType],
     ):
         super().__init__(uid)
         assert hazard in HAZARDS_MAPPING, f"Invalid hazard type {hazard}."
@@ -73,7 +73,10 @@ class SafeTest(PromptResponseTest):
         self.folder_name = folder_name
         self.together_api_key = together_api_key
         assert len(persona_types), "At least one persona type must be specified."
-        self.persona_types: List[PersonaType] = sorted(persona_types)
+        assert len(set(persona_types)) == len(
+            persona_types
+        ), f"Must specify a unique set of persona types, but got {persona_types}"
+        self.persona_types = persona_types
 
     def _persona_dependency_key(self, persona: PersonaType) -> str:
         return f"{self.folder_name}_{self.hazard}_{persona}"
@@ -156,7 +159,7 @@ TESTS.register(
     "ben",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types={PersonaType.TYPICAL},
+    persona_types=[PersonaType.TYPICAL],
 )
 
 TESTS.register(
@@ -165,7 +168,7 @@ TESTS.register(
     "cae",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types={PersonaType.TYPICAL, PersonaType.MALICIOUS},
+    persona_types=[PersonaType.TYPICAL, PersonaType.MALICIOUS],
 )
 TESTS.register(
     SafeTest,
@@ -173,7 +176,7 @@ TESTS.register(
     "cbr",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types={PersonaType.TYPICAL, PersonaType.MALICIOUS},
+    persona_types=[PersonaType.TYPICAL, PersonaType.MALICIOUS],
 )
 TESTS.register(
     SafeTest,
@@ -181,7 +184,7 @@ TESTS.register(
     "hat",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types={PersonaType.TYPICAL, PersonaType.MALICIOUS},
+    persona_types=[PersonaType.TYPICAL, PersonaType.MALICIOUS],
 )
 TESTS.register(
     SafeTest,
@@ -189,7 +192,7 @@ TESTS.register(
     "nvc",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types={PersonaType.TYPICAL, PersonaType.MALICIOUS},
+    persona_types=[PersonaType.TYPICAL, PersonaType.MALICIOUS],
 )
 TESTS.register(
     SafeTest,
@@ -197,7 +200,7 @@ TESTS.register(
     "scr",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types={PersonaType.TYPICAL, PersonaType.MALICIOUS},
+    persona_types=[PersonaType.TYPICAL, PersonaType.MALICIOUS],
 )
 TESTS.register(
     SafeTest,
@@ -213,5 +216,5 @@ TESTS.register(
     "vcr",
     FOLDER_NAME,
     API_KEY_SECRET,
-    persona_types={PersonaType.TYPICAL, PersonaType.MALICIOUS},
+    persona_types=[PersonaType.TYPICAL, PersonaType.MALICIOUS],
 )

--- a/plugins/standard_tests/newhelm/tests/safe.py
+++ b/plugins/standard_tests/newhelm/tests/safe.py
@@ -22,7 +22,7 @@ from newhelm.suts.together_client import TogetherApiKey
 from newhelm.test_decorator import newhelm_test
 from newhelm.test_registry import TESTS
 from pydantic import BaseModel
-from typing import Dict, List, Mapping, Set
+from typing import Dict, List, Mapping
 
 HAZARDS_MAPPING = {
     "ben": "Benign",

--- a/plugins/standard_tests/tests/test_safe.py
+++ b/plugins/standard_tests/tests/test_safe.py
@@ -161,9 +161,13 @@ def test_multiple_personas_test_items(tmpdir):
         persona_types=[_PERSONA_1, _PERSONA_2],
     )
     items = test.make_test_items(dependency_helper)
-    assert {
-        (item.prompts[0].prompt.text, item.context.persona_type) for item in items
-    } == set(zip(prompts, [_PERSONA_1, _PERSONA_2, _PERSONA_2]))
+    assert [item.context.persona_type for item in items] == [
+        _PERSONA_1,
+        _PERSONA_2,
+        _PERSONA_2,
+    ]
+    # Ensure we got all the right prompts, and in a stable order.
+    assert [item.prompts[0].prompt.text for item in items] == prompts
 
 
 def test_unknown_hazard_exception():


### PR DESCRIPTION
Passing through `set` caused each run to have a different ordering of personas.