### PR TITLE
Loading bar for plugins

### DIFF
--- a/newhelm/load_plugins.py
+++ b/newhelm/load_plugins.py
@@ -10,7 +10,10 @@ To see this in action:
 
 The demo plugin modules will only print on the second run.
 """
+
 import importlib
+
+from tqdm import tqdm
 import newhelm
 import newhelm.annotators
 import newhelm.runners
@@ -33,6 +36,8 @@ def list_plugins() -> List[str]:
     return module_names
 
 
-def load_plugins() -> None:
-    for module_name in list_plugins():
+def load_plugins(disable_progress_bar: bool = False) -> None:
+    for module_name in tqdm(
+        list_plugins(), desc="Loading plugins", disable=disable_progress_bar
+    ):
         importlib.import_module(module_name)


### PR DESCRIPTION
While experimenting with caching I was trying to figure out why the fully cached runs were taking so long to do anything at startup. I'm reasonably sure that delay is caused by load_plugins, which on my computer seems to average 2 seconds with `all_plugins` installed.

Ideally we should make this faster, but for now having the bar at least reassures the user we didn't hang.