### PR TITLE
Have `list` command report prettier values for secrets

### DIFF
--- a/newhelm/secret_values.py
+++ b/newhelm/secret_values.py
@@ -149,3 +149,6 @@ class InjectSecret(Injector, Generic[SecretType]):
 
     def inject(self, raw_secrets: RawSecrets) -> SecretType:
         return self.secret_class.make(raw_secrets)
+
+    def __repr__(self):
+        return f"InjectSecret({self.secret_class.__name__})"

--- a/tests/test_instance_factory.py
+++ b/tests/test_instance_factory.py
@@ -171,3 +171,27 @@ def test_kwargs_injection():
     k2_obj = factory.make_instance("k2", secrets=secrets)
     assert k2_obj.arg1 == "v2"
     assert k2_obj.kwargs == {"fake_secret": FakeRequiredSecret("some-value")}
+
+
+def test_display_basic():
+    entry = FactoryEntry(MockClass, "some-uid", (), {})
+    assert str(entry) == "MockClass(uid=some-uid, args=(), kwargs={})"
+
+
+def test_display_with_args():
+    entry = FactoryEntry(MockClass, "some-uid", ("v1"), {"arg2": "v2"})
+    assert str(entry) == "MockClass(uid=some-uid, args=v1, kwargs={'arg2': 'v2'})"
+
+
+def test_display_with_secrets():
+    entry = FactoryEntry(
+        MockClass,
+        "some-uid",
+        (InjectSecret(FakeRequiredSecret)),
+        {"arg2": InjectSecret(FakeRequiredSecret)},
+    )
+    assert str(entry) == (
+        "MockClass(uid=some-uid, "
+        "args=InjectSecret(FakeRequiredSecret), "
+        "kwargs={'arg2': InjectSecret(FakeRequiredSecret)})"
+    )


### PR DESCRIPTION
* Before: `llama-2-7b TogetherCompletionsSUT(uid=llama-2-7b, args=('meta-llama/Llama-2-7b-hf', <newhelm.secret_values.InjectSecret object at 0x7f038a5607f0>), kwargs={})`
* After: `llama-2-7b TogetherCompletionsSUT(uid=llama-2-7b, args=('meta-llama/Llama-2-7b-hf', InjectSecret(TogetherApiKey)), kwargs={})`