### PR TITLE
Avoid rate limit error on scheduled daily test

### DIFF
--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -90,4 +90,3 @@ jobs:
         RUN_ID: ${{ github.run_id }}
       with:
         filename: .github/failed-scheduled-issue.md
-        update_existing: true


### PR DESCRIPTION
* Avoid rate limit error on scheduled daily test

There appears to be an issue when scanning issues for a matching issue title which triggers a secondary rate limit error. As this is not the primary feature we are using and an optimization, removing this for now

See: https://github.com/mlcommons/newhelm/actions/runs/8604877224/job/23579923706
See: https://github.com/JasonEtco/create-an-issue/issues/142